### PR TITLE
alsa-lib: add support for pistachio-card in alsa-lib.

### DIFF
--- a/libs/alsa-lib/patches/006-add-pistachio-card-conf.patch
+++ b/libs/alsa-lib/patches/006-add-pistachio-card-conf.patch
@@ -1,0 +1,60 @@
+diff -Naur a/src/conf/cards/aliases.conf b/src/conf/cards/aliases.conf
+--- a/src/conf/cards/aliases.conf	2015-11-09 13:09:18.000000000 +0530
++++ b/src/conf/cards/aliases.conf	2016-10-12 17:58:40.963159808 +0530
+@@ -55,6 +55,7 @@
+ AV200 cards.CMI8788
+ CMI8786 cards.CMI8788
+ CMI8787 cards.CMI8788
++pistachio cards.pistachio-card
+ 
+ <confdir:pcm/default.conf>
+ <confdir:pcm/dmix.conf>
+diff -Naur a/src/conf/cards/Makefile.am b/src/conf/cards/Makefile.am
+--- a/src/conf/cards/Makefile.am	2015-11-09 13:09:18.000000000 +0530
++++ b/src/conf/cards/Makefile.am	2016-10-12 17:58:40.967159808 +0530
+@@ -39,6 +39,7 @@
+ 	Maestro3.conf \
+ 	NFORCE.conf \
+ 	PC-Speaker.conf \
++	pistachio-card.conf \
+ 	PMac.conf \
+ 	PMacToonie.conf \
+ 	PS3.conf \
+diff -Naur a/src/conf/cards/pistachio-card.conf b/src/conf/cards/pistachio-card.conf
+--- a/src/conf/cards/pistachio-card.conf 2015-11-09 13:09:18.000000000 +0530
++++ b/src/conf/cards/pistachio-card.conf 2016-10-12 17:58:40.967159808 +0530
+@@ -0,0 +1,34 @@
++#
++# Configuration for the pistachio chip
++#
++
++pistachio-card.pcm.default{
++        @args [ CARD ]
++        @args.CARD {
++                type string
++                default "pistachio"
++        }
++        @args.DEVICE {
++                type integer
++                default 2
++        }
++
++        type asym
++        capture.pcm {
++                type multi
++                slaves.a.pcm "hw:0,4"
++                slaves.a.channels 12
++                bindings.0.slave a
++                bindings.0.channel 4
++                bindings.1.slave a
++                bindings.1.channel 5
++        }
++
++        playback.pcm {
++                type hw
++                card $CARD
++                device $DEVICE
++
++        }
++
++}


### PR DESCRIPTION
This fixes CreatorDev/openwrt#25