### PR TITLE
Gst alsa start at

### DIFF
--- a/libs/alsa-lib/patches/007-add-start_at-modifications-to-alsa-lib.patch
+++ b/libs/alsa-lib/patches/007-add-start_at-modifications-to-alsa-lib.patch
@@ -1,0 +1,1230 @@
+From 122568912d017108ff7e04de05891cb47f3cab8a Mon Sep 17 00:00:00 2001
+From: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+Date: Fri, 25 Nov 2016 15:56:15 +0530
+Subject: [PATCH] add start_at modifications to alsa-lib
+
+Add API for starting a playback stream at a specified absolute
+time. Both system (posix) and audio hardware clocks are supported.
+
+Use snd_pcm_start_at_system() for system clocks, and
+snd_pcm_start_at_audio() for audio clocks.
+
+snd_pcm_start_at_abort() cancels a previous start_at request.
+
+Signed-off-by: Damien.Horsley <Damien.Horsley@imgtec.com>
+Signed-off-by: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+---
+ include/pcm.h          | 22 +++++++++++-
+ include/sound/asound.h | 22 ++++++++++++
+ src/pcm/pcm.c          | 93 ++++++++++++++++++++++++++++++++++++++++++++++----
+ src/pcm/pcm_dmix.c     | 40 +++++++++++++++++-----
+ src/pcm/pcm_dshare.c   | 33 ++++++++++++++----
+ src/pcm/pcm_dsnoop.c   | 33 +++++++++++++++---
+ src/pcm/pcm_file.c     | 12 +++++++
+ src/pcm/pcm_hooks.c    | 11 ++++++
+ src/pcm/pcm_hw.c       | 24 +++++++++++++
+ src/pcm/pcm_local.h    |  5 ++-
+ src/pcm/pcm_meter.c    | 12 +++++++
+ src/pcm/pcm_mmap.c     |  8 ++---
+ src/pcm/pcm_multi.c    | 25 ++++++++++++++
+ src/pcm/pcm_null.c     | 13 +++++++
+ src/pcm/pcm_plugin.c   | 12 +++++++
+ src/pcm/pcm_rate.c     | 11 ++++++
+ src/pcm/pcm_share.c    | 42 ++++++++++++++++++-----
+ test/pcm.c             |  5 ++-
+ 18 files changed, 383 insertions(+), 40 deletions(-)
+
+diff --git a/include/pcm.h b/include/pcm.h
+index 0be1a32..b0542e9 100644
+--- a/include/pcm.h
++++ b/include/pcm.h
+@@ -289,7 +289,9 @@ typedef enum _snd_pcm_state {
+ 	SND_PCM_STATE_SUSPENDED,
+ 	/** Hardware is disconnected */
+ 	SND_PCM_STATE_DISCONNECTED,
+-	SND_PCM_STATE_LAST = SND_PCM_STATE_DISCONNECTED
++	/** Stream is starting on a start_at timer */
++	SND_PCM_STATE_STARTING,
++	SND_PCM_STATE_LAST = SND_PCM_STATE_STARTING,
+ } snd_pcm_state_t;
+ 
+ /** PCM start mode */
+@@ -330,6 +332,22 @@ typedef enum _snd_pcm_tstamp_type {
+ 	SND_PCM_TSTAMP_TYPE_LAST = SND_PCM_TSTAMP_TYPE_MONOTONIC_RAW,
+ } snd_pcm_tstamp_type_t;
+ 
++typedef enum _snd_pcm_audio_tstamp_type {
++	/*
++	 *  first definition for backwards compatibility only,
++	 *  maps to wallclock/link time for HDAudio playback and DEFAULT/DMA time for everything else
++	 */
++	SND_PCM_AUDIO_TSTAMP_TYPE_COMPAT = 0,
++
++	/* timestamp definitions */
++	SND_PCM_AUDIO_TSTAMP_TYPE_DEFAULT = 1,           /* DMA time, reported as per hw_ptr */
++	SND_PCM_AUDIO_TSTAMP_TYPE_LINK = 2,              /* link time reported by sample or wallclock counter, reset on startup */
++	SND_PCM_AUDIO_TSTAMP_TYPE_LINK_ABSOLUTE = 3,     /* link time reported by sample or wallclock counter, not reset on startup */
++	SND_PCM_AUDIO_TSTAMP_TYPE_LINK_ESTIMATED = 4,    /* link time estimated indirectly */
++	SND_PCM_AUDIO_TSTAMP_TYPE_LINK_SYNCHRONIZED = 5, /* link time synchronized with system time */
++	SND_PCM_AUDIO_TSTAMP_TYPE_LAST = SND_PCM_AUDIO_TSTAMP_TYPE_LINK_SYNCHRONIZED
++} snd_pcm_audio_tstamp_type_t;
++
+ typedef struct _snd_pcm_audio_tstamp_config {
+ 	/* 5 of max 16 bits used */
+ 	unsigned int type_requested:4;
+@@ -498,6 +516,8 @@ int snd_pcm_prepare(snd_pcm_t *pcm);
+ int snd_pcm_reset(snd_pcm_t *pcm);
+ int snd_pcm_status(snd_pcm_t *pcm, snd_pcm_status_t *status);
+ int snd_pcm_start(snd_pcm_t *pcm);
++int snd_pcm_start_at_system(snd_pcm_t *pcm, snd_pcm_tstamp_type_t system_clock_type, const snd_htimestamp_t* start_time);
++int snd_pcm_start_at_audio(snd_pcm_t *pcm, snd_pcm_audio_tstamp_type_t audio_clock_type, const snd_htimestamp_t* start_time);
+ int snd_pcm_drop(snd_pcm_t *pcm);
+ int snd_pcm_drain(snd_pcm_t *pcm);
+ int snd_pcm_pause(snd_pcm_t *pcm, int enable);
+diff --git a/include/sound/asound.h b/include/sound/asound.h
+index 67bf49d..af1ea6d 100644
+--- a/include/sound/asound.h
++++ b/include/sound/asound.h
+@@ -297,6 +297,7 @@ typedef int __bitwise snd_pcm_state_t;
+ #define	SNDRV_PCM_STATE_PAUSED		((__force snd_pcm_state_t) 6) /* stream is paused */
+ #define	SNDRV_PCM_STATE_SUSPENDED	((__force snd_pcm_state_t) 7) /* hardware is suspended */
+ #define	SNDRV_PCM_STATE_DISCONNECTED	((__force snd_pcm_state_t) 8) /* hardware is disconnected */
++#define SNDRV_PCM_STATE_STARTING        ((__force snd_pcm_state_t) 9) /* stream start has been delegated to the kernel */
+ #define	SNDRV_PCM_STATE_LAST		SNDRV_PCM_STATE_DISCONNECTED
+ 
+ enum {
+@@ -507,6 +508,26 @@ enum {
+ 	SNDRV_PCM_TSTAMP_TYPE_LAST = SNDRV_PCM_TSTAMP_TYPE_MONOTONIC_RAW,
+ };
+ 
++enum {
++	SNDRV_PCM_CLOCK_CLASS_SYSTEM = 0,
++	SNDRV_PCM_CLOCK_CLASS_AUDIO,
++	SNDRV_PCM_CLOCK_CLASS_LAST = SNDRV_PCM_CLOCK_CLASS_AUDIO,
++};
++
++struct snd_pcm_startat_state {
++	int pending;                    /* 0 or 1 */
++	int clock_class;                /* SNDRV_PCM_CLOCK_CLASS_* */
++	int clock_type;                 /* SNDRV_PCM_TSTAMP_* or
++	                                         * SNDRV_PCM_AUDIO_TSTAMP_TYPE_* */
++	struct timespec start_time;
++};
++
++struct snd_startat {
++	int clock_class;
++	int clock_type;
++	struct timespec start_time;
++};
++
+ /* channel positions */
+ enum {
+ 	SNDRV_CHMAP_UNKNOWN = 0,
+@@ -586,6 +607,7 @@ enum {
+ #define SNDRV_PCM_IOCTL_READN_FRAMES	_IOR('A', 0x53, struct snd_xfern)
+ #define SNDRV_PCM_IOCTL_LINK		_IOW('A', 0x60, int)
+ #define SNDRV_PCM_IOCTL_UNLINK		_IO('A', 0x61)
++#define SNDRV_PCM_IOCTL_START_AT        _IOW('A', 0x62, struct snd_startat)
+ 
+ /*****************************************************************************
+  *                                                                           *
+diff --git a/src/pcm/pcm.c b/src/pcm/pcm.c
+index 203e7a5..94422e1 100644
+--- a/src/pcm/pcm.c
++++ b/src/pcm/pcm.c
+@@ -206,6 +206,11 @@ to leave this state.
+ \par SND_PCM_STATE_DISCONNECTED
+ The device is physicaly disconnected. It does not accept any I/O calls in this state.
+ 
++\par SND_PCM_STATE_STARTING
++The device is waiting to start on a kernel/hardware timer. Abort by calling
++#snd_pcm_drop().
++
++
+ \section pcm_formats PCM formats
+ 
+ The full list of formats present the #snd_pcm_format_t type.
+@@ -448,6 +453,14 @@ to the #SND_PCM_STATE_PREPARED after a successful finish.
+ The #snd_pcm_start() function enters
+ the #SND_PCM_STATE_RUNNING after a successful finish.
+ 
++\par snd_pcm_start_at_system
++The #snd_pcm_start_at_system function starts the stream
++at an abolute time with respect to the specified system clock.
++
++\par snd_pcm_start_at_audio
++The #snd_pcm_start_at_audio function starts the stream
++at an abolute time with respect to the specified audio clock.
++
+ \par snd_pcm_drop
+ The #snd_pcm_drop() function enters the
+ #SND_PCM_STATE_SETUP state.
+@@ -1083,6 +1096,61 @@ int snd_pcm_start(snd_pcm_t *pcm)
+ 	return pcm->fast_ops->start(pcm->fast_op_arg);
+ }
+ 
++static int snd_pcm_start_at(snd_pcm_t* pcm, int clock_class, int clock_type, const snd_htimestamp_t *start_time)
++{
++	assert(pcm);
++	assert(start_time);
++	if (CHECK_SANITY(! pcm->setup)) {
++		SNDMSG("PCM not set up");
++		return -EIO;
++	}
++	if (pcm->fast_ops->start_at) {
++		return pcm->fast_ops->start_at(pcm->fast_op_arg, clock_class, clock_type, start_time);
++	}
++	return -EINVAL;
++}
++
++/**
++ * \brief Start a PCM at a future time, according to a system clock
++ * \param pcm PCM handle
++ * \param system_clock_type Specifies the system clock with which to interpret \p start_time
++ * \param start_time Absolute time at which to start the stream
++ * \return 0 on success otherwise a negative error code
++ * \retval -ENOSYS operation not supported for the current timestamp type
++ * \retval -EINPROGRESS start_at timer is already active
++ * \retval -EINVAL timespec, tstamp_class or tstamp_type is invalid
++ * \retval -ETIME requested start_time cannot be satisfied
++ *
++ * This method is non-blocking: It establishes an appropriate timer in the kernel
++ * that will start the stream on expiry. The stream moves to #SND_PCM_STATE_STARTING.
++ * Use #snd_pcm_drop() to abort and return to #SND_PCM_STATE_SETUP.
++ */
++int snd_pcm_start_at_system(snd_pcm_t *pcm, snd_pcm_tstamp_type_t system_clock_type, const snd_htimestamp_t* start_time)
++{
++	       return snd_pcm_start_at(pcm, SNDRV_PCM_CLOCK_CLASS_SYSTEM, system_clock_type, start_time);
++}
++
++/**
++ * \brief Start a PCM at a future time, according to a audio clock
++ * \param pcm PCM handle
++ * \param audio_clock_type Specifies the audio clock with which to interpret \p start_time
++ * \param start_time Absolute time at which to start the stream
++ * \return 0 on success otherwise a negative error code
++ * \retval -ENOSYS operation not supported for the current timestamp type
++ * \retval -EINPROGRESS start_at timer is already active
++ * \retval -EINVAL timespec, tstamp_class or tstamp_type is invalid
++ * \retval -ETIME requested start_time cannot be satisfied
++ *
++ * This method is non-blocking: It establishes an appropriate timer in the kernel
++ * that will start the stream on expiry. The stream moves to #SND_PCM_STATE_STARTING
++ * Use #snd_pcm_drop() to abort and return to #SND_PCM_STATE_SETUP.
++ */
++int snd_pcm_start_at_audio(snd_pcm_t *pcm, snd_pcm_audio_tstamp_type_t audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	       return snd_pcm_start_at(pcm, SNDRV_PCM_CLOCK_CLASS_AUDIO, audio_clock_type, start_time);
++}
++
++
+ /**
+  * \brief Stop a PCM dropping pending frames
+  * \param pcm PCM handle
+@@ -1510,6 +1578,7 @@ static const char *const snd_pcm_state_names[] = {
+ 	STATE(PAUSED),
+ 	STATE(SUSPENDED),
+ 	STATE(DISCONNECTED),
++	STATE(STARTING),
+ };
+ 
+ static const char *const snd_pcm_access_names[] = {
+@@ -6830,6 +6899,7 @@ snd_pcm_sframes_t snd_pcm_read_areas(snd_pcm_t *pcm, const snd_pcm_channel_area_
+ 				goto _end;
+ 			break;
+ 		case SND_PCM_STATE_RUNNING:
++		case SND_PCM_STATE_STARTING:
+ 			err = snd_pcm_hwsync(pcm);
+ 			if (err < 0)
+ 				goto _end;
+@@ -6907,9 +6977,12 @@ snd_pcm_sframes_t snd_pcm_write_areas(snd_pcm_t *pcm, const snd_pcm_channel_area
+ 		case SND_PCM_STATE_PAUSED:
+ 			break;
+ 		case SND_PCM_STATE_RUNNING:
++		case SND_PCM_STATE_STARTING:
+ 			err = snd_pcm_hwsync(pcm);
+-			if (err < 0)
++			if (err < 0) {
++				printf("snd_pcm_write_areas _again state %u err %d\n", (unsigned int)state, (int)err);
+ 				goto _end;
++			}
+ 			break;
+ 		case SND_PCM_STATE_XRUN:
+ 			err = -EPIPE;
+@@ -6926,20 +6999,24 @@ snd_pcm_sframes_t snd_pcm_write_areas(snd_pcm_t *pcm, const snd_pcm_channel_area
+ 		}
+ 		avail = snd_pcm_avail_update(pcm);
+ 		if (avail < 0) {
++			printf("snd_pcm_write_areas snd_pcm_avail_update err %d\n", (int)err);
+ 			err = avail;
+ 			goto _end;
+ 		}
+-		if ((state == SND_PCM_STATE_RUNNING &&
++		if (((state == SND_PCM_STATE_RUNNING) || (state == SND_PCM_STATE_STARTING)) &&
+ 		     size > (snd_pcm_uframes_t)avail &&
+-		     snd_pcm_may_wait_for_avail_min(pcm, avail))) {
++		     snd_pcm_may_wait_for_avail_min(pcm, avail)) {
+ 			if (pcm->mode & SND_PCM_NONBLOCK) {
+ 				err = -EAGAIN;
+ 				goto _end;
+ 			}
+ 
+ 			err = snd_pcm_wait_nocheck(pcm, -1);
+-			if (err < 0)
++			if (err < 0) {
++				printf("snd_pcm_write_areas snd_pcm_wait_nocheck err %d\n", (int)err);
+ 				break;
++			}
++
+ 			goto _again;			
+ 		}
+ 		frames = size;
+@@ -6948,8 +7025,10 @@ snd_pcm_sframes_t snd_pcm_write_areas(snd_pcm_t *pcm, const snd_pcm_channel_area
+ 		if (! frames)
+ 			break;
+ 		err = func(pcm, areas, offset, frames);
+-		if (err < 0)
++		if (err < 0) {
++			printf("snd_pcm_write_areas func err %d\n", (int)err);
+ 			break;
++		}
+ 		frames = err;
+ 		if (state == SND_PCM_STATE_PREPARED) {
+ 			snd_pcm_sframes_t hw_avail = pcm->buffer_size - avail;
+@@ -6959,8 +7038,10 @@ snd_pcm_sframes_t snd_pcm_write_areas(snd_pcm_t *pcm, const snd_pcm_channel_area
+ 			if (state == SND_PCM_STATE_PREPARED &&
+ 			    hw_avail >= (snd_pcm_sframes_t) pcm->start_threshold) {
+ 				err = snd_pcm_start(pcm);
+-				if (err < 0)
++				if (err < 0) {
++					printf("snd_pcm_write_areas snd_pcm_start err %d\n", (int)err);
+ 					goto _end;
++				}
+ 			}
+ 		}
+ 		offset += frames;
+diff --git a/src/pcm/pcm_dmix.c b/src/pcm/pcm_dmix.c
+index b26a5c7..9292e16 100644
+--- a/src/pcm/pcm_dmix.c
++++ b/src/pcm/pcm_dmix.c
+@@ -412,7 +412,8 @@ static int snd_pcm_dmix_sync_ptr(snd_pcm_t *pcm)
+ 	if (diff == 0)		/* fast path */
+ 		return 0;
+ 	if (dmix->state != SND_PCM_STATE_RUNNING &&
+-	    dmix->state != SND_PCM_STATE_DRAINING)
++	    dmix->state != SND_PCM_STATE_DRAINING &&
++	    dmix->state != SND_PCM_STATE_STARTING)
+ 		/* not really started yet - don't update hw_ptr */
+ 		return 0;
+ 	if (diff < 0) {
+@@ -429,7 +430,8 @@ static int snd_pcm_dmix_sync_ptr(snd_pcm_t *pcm)
+ 	if (avail >= pcm->stop_threshold) {
+ 		snd_timer_stop(dmix->timer);
+ 		gettimestamp(&dmix->trigger_tstamp, pcm->tstamp_type);
+-		if (dmix->state == SND_PCM_STATE_RUNNING) {
++		if (dmix->state == SND_PCM_STATE_RUNNING ||
++		    dmix->state == SND_PCM_STATE_STARTING) {
+ 			dmix->state = SND_PCM_STATE_XRUN;
+ 			return -EPIPE;
+ 		}
+@@ -470,6 +472,7 @@ static int snd_pcm_dmix_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ 	switch (dmix->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		snd_pcm_dmix_sync_ptr(pcm);
+ 		break;
+ 	default:
+@@ -494,6 +497,7 @@ static int snd_pcm_dmix_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
+ 	switch(dmix->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		err = snd_pcm_dmix_sync_ptr(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -519,6 +523,7 @@ static int snd_pcm_dmix_hwsync(snd_pcm_t *pcm)
+ 	switch(dmix->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		/* sync slave PCM */
+ 		return snd_pcm_dmix_sync_ptr(pcm);
+ 	case SNDRV_PCM_STATE_PREPARED:
+@@ -591,6 +596,16 @@ static int snd_pcm_dmix_start(snd_pcm_t *pcm)
+ 	return 0;
+ }
+ 
++int snd_pcm_dmix_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_direct_t *dmix = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(dmix->spcm, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(dmix->spcm, audio_clock_type, start_time);
++}
++
+ static int snd_pcm_dmix_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_direct_t *dmix = pcm->private_data;
+@@ -678,7 +693,9 @@ static snd_pcm_sframes_t snd_pcm_dmix_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t f
+ 	const snd_pcm_channel_area_t *src_areas, *dst_areas;
+ 
+ 	if (dmix->state == SND_PCM_STATE_RUNNING ||
+-	    dmix->state == SND_PCM_STATE_DRAINING) {
++	    dmix->state == SND_PCM_STATE_DRAINING ||
++	    dmix->state == SND_PCM_STATE_STARTING) {
++
+ 		err = snd_pcm_dmix_hwsync(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -819,10 +836,13 @@ static snd_pcm_sframes_t snd_pcm_dmix_mmap_commit(snd_pcm_t *pcm,
+ 		if ((err = snd_pcm_dmix_start_timer(pcm, dmix)) < 0)
+ 			return err;
+ 	} else if (dmix->state == SND_PCM_STATE_RUNNING ||
+-		   dmix->state == SND_PCM_STATE_DRAINING)
++		   dmix->state == SND_PCM_STATE_DRAINING ||
++		   dmix->state == SND_PCM_STATE_STARTING)
++
+ 		snd_pcm_dmix_sync_ptr(pcm);
+ 	if (dmix->state == SND_PCM_STATE_RUNNING ||
+-	    dmix->state == SND_PCM_STATE_DRAINING) {
++	    dmix->state == SND_PCM_STATE_DRAINING ||
++	    dmix->state == SND_PCM_STATE_STARTING) {
+ 		/* ok, we commit the changes after the validation of area */
+ 		/* it's intended, although the result might be crappy */
+ 		snd_pcm_dmix_sync_area(pcm);
+@@ -838,7 +858,8 @@ static snd_pcm_sframes_t snd_pcm_dmix_avail_update(snd_pcm_t *pcm)
+ 	snd_pcm_direct_t *dmix = pcm->private_data;
+ 	
+ 	if (dmix->state == SND_PCM_STATE_RUNNING ||
+-	    dmix->state == SND_PCM_STATE_DRAINING)
++	    dmix->state == SND_PCM_STATE_DRAINING ||
++	    dmix->state == SND_PCM_STATE_STARTING)
+ 		snd_pcm_dmix_sync_ptr(pcm);
+ 	return snd_pcm_mmap_playback_avail(pcm);
+ }
+@@ -853,7 +874,8 @@ static int snd_pcm_dmix_htimestamp(snd_pcm_t *pcm,
+ 	
+ 	while (1) {
+ 		if (dmix->state == SND_PCM_STATE_RUNNING ||
+-		    dmix->state == SND_PCM_STATE_DRAINING)
++		    dmix->state == SND_PCM_STATE_DRAINING ||
++		    dmix->state != SND_PCM_STATE_STARTING)
+ 			snd_pcm_dmix_sync_ptr(pcm);
+ 		avail1 = snd_pcm_mmap_playback_avail(pcm);
+ 		if (ok && *avail == avail1)
+@@ -868,7 +890,8 @@ static int snd_pcm_dmix_htimestamp(snd_pcm_t *pcm,
+ static int snd_pcm_dmix_poll_revents(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int nfds, unsigned short *revents)
+ {
+ 	snd_pcm_direct_t *dmix = pcm->private_data;
+-	if (dmix->state == SND_PCM_STATE_RUNNING)
++	if (dmix->state == SND_PCM_STATE_RUNNING ||
++	    dmix->state == SND_PCM_STATE_STARTING)
+ 		snd_pcm_dmix_sync_area(pcm);
+ 	return snd_pcm_direct_poll_revents(pcm, pfds, nfds, revents);
+ }
+@@ -913,6 +936,7 @@ static const snd_pcm_fast_ops_t snd_pcm_dmix_fast_ops = {
+ 	.prepare = snd_pcm_direct_prepare,
+ 	.reset = snd_pcm_dmix_reset,
+ 	.start = snd_pcm_dmix_start,
++	.start_at = snd_pcm_dmix_start_at,
+ 	.drop = snd_pcm_dmix_drop,
+ 	.drain = snd_pcm_dmix_drain,
+ 	.pause = snd_pcm_dmix_pause,
+diff --git a/src/pcm/pcm_dshare.c b/src/pcm/pcm_dshare.c
+index 58e47bb..c01427e 100644
+--- a/src/pcm/pcm_dshare.c
++++ b/src/pcm/pcm_dshare.c
+@@ -178,7 +178,8 @@ static int snd_pcm_dshare_sync_ptr(snd_pcm_t *pcm)
+ 	if (diff == 0)		/* fast path */
+ 		return 0;
+ 	if (dshare->state != SND_PCM_STATE_RUNNING &&
+-	    dshare->state != SND_PCM_STATE_DRAINING)
++	    dshare->state != SND_PCM_STATE_DRAINING &&
++	    dshare->state != SND_PCM_STATE_STARTING)
+ 		/* not really started yet - don't update hw_ptr */
+ 		return 0;
+ 	if (diff < 0) {
+@@ -196,7 +197,8 @@ static int snd_pcm_dshare_sync_ptr(snd_pcm_t *pcm)
+ 	if (avail >= pcm->stop_threshold) {
+ 		snd_timer_stop(dshare->timer);
+ 		gettimestamp(&dshare->trigger_tstamp, pcm->tstamp_type);
+-		if (dshare->state == SND_PCM_STATE_RUNNING) {
++		if (dshare->state == SND_PCM_STATE_RUNNING ||
++		    dshare->state == SND_PCM_STATE_STARTING) {
+ 			dshare->state = SND_PCM_STATE_XRUN;
+ 			return -EPIPE;
+ 		}
+@@ -218,6 +220,7 @@ static int snd_pcm_dshare_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ 	switch (dshare->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		snd_pcm_dshare_sync_ptr(pcm);
+ 		break;
+ 	default:
+@@ -261,6 +264,7 @@ static int snd_pcm_dshare_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
+ 	switch (dshare->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		err = snd_pcm_dshare_sync_ptr(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -286,6 +290,7 @@ static int snd_pcm_dshare_hwsync(snd_pcm_t *pcm)
+ 	switch(dshare->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		return snd_pcm_dshare_sync_ptr(pcm);
+ 	case SNDRV_PCM_STATE_PREPARED:
+ 	case SNDRV_PCM_STATE_SUSPENDED:
+@@ -343,6 +348,17 @@ static int snd_pcm_dshare_start(snd_pcm_t *pcm)
+ 	return 0;
+ }
+ 
++int snd_pcm_dshare_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_direct_t *dshare = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(dshare->spcm, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(dshare->spcm, audio_clock_type, start_time);
++}
++
++
+ static int snd_pcm_dshare_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_direct_t *dshare = pcm->private_data;
+@@ -506,10 +522,12 @@ static snd_pcm_sframes_t snd_pcm_dshare_mmap_commit(snd_pcm_t *pcm,
+ 		if ((err = snd_pcm_dshare_start_timer(dshare)) < 0)
+ 			return err;
+ 	} else if (dshare->state == SND_PCM_STATE_RUNNING ||
+-		   dshare->state == SND_PCM_STATE_DRAINING)
++		   dshare->state == SND_PCM_STATE_DRAINING ||
++		   dshare->state == SND_PCM_STATE_STARTING)
+ 		snd_pcm_dshare_sync_ptr(pcm);
+ 	if (dshare->state == SND_PCM_STATE_RUNNING ||
+-	    dshare->state == SND_PCM_STATE_DRAINING) {
++	    dshare->state == SND_PCM_STATE_DRAINING ||
++	    dshare->state == SND_PCM_STATE_STARTING) {
+ 		/* ok, we commit the changes after the validation of area */
+ 		/* it's intended, although the result might be crappy */
+ 		snd_pcm_dshare_sync_area(pcm);
+@@ -525,7 +543,8 @@ static snd_pcm_sframes_t snd_pcm_dshare_avail_update(snd_pcm_t *pcm)
+ 	snd_pcm_direct_t *dshare = pcm->private_data;
+ 	
+ 	if (dshare->state == SND_PCM_STATE_RUNNING ||
+-	    dshare->state == SND_PCM_STATE_DRAINING)
++	    dshare->state == SND_PCM_STATE_DRAINING ||
++	    dshare->state == SND_PCM_STATE_STARTING)
+ 		snd_pcm_dshare_sync_ptr(pcm);
+ 	return snd_pcm_mmap_playback_avail(pcm);
+ }
+@@ -540,7 +559,8 @@ static int snd_pcm_dshare_htimestamp(snd_pcm_t *pcm,
+ 	
+ 	while (1) {
+ 		if (dshare->state == SND_PCM_STATE_RUNNING ||
+-		    dshare->state == SND_PCM_STATE_DRAINING)
++		    dshare->state == SND_PCM_STATE_DRAINING ||
++		    dshare->state == SND_PCM_STATE_STARTING)
+ 			snd_pcm_dshare_sync_ptr(pcm);
+ 		avail1 = snd_pcm_mmap_playback_avail(pcm);
+ 		if (ok && *avail == avail1)
+@@ -590,6 +610,7 @@ static const snd_pcm_fast_ops_t snd_pcm_dshare_fast_ops = {
+ 	.prepare = snd_pcm_direct_prepare,
+ 	.reset = snd_pcm_dshare_reset,
+ 	.start = snd_pcm_dshare_start,
++	.start_at = snd_pcm_dshare_start_at,
+ 	.drop = snd_pcm_dshare_drop,
+ 	.drain = snd_pcm_dshare_drain,
+ 	.pause = snd_pcm_dshare_pause,
+diff --git a/src/pcm/pcm_dsnoop.c b/src/pcm/pcm_dsnoop.c
+index 576c35b..44fef0d 100644
+--- a/src/pcm/pcm_dsnoop.c
++++ b/src/pcm/pcm_dsnoop.c
+@@ -181,6 +181,7 @@ static int snd_pcm_dsnoop_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ 	switch(dsnoop->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		snd_pcm_dsnoop_sync_ptr(pcm);
+ 		break;
+ 	default:
+@@ -189,7 +190,7 @@ static int snd_pcm_dsnoop_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ 	memset(status, 0, sizeof(*status));
+ 	snd_pcm_status(dsnoop->spcm, status);
+ 	state = snd_pcm_state(dsnoop->spcm);
+-	status->state = state == SND_PCM_STATE_RUNNING ? dsnoop->state : state;
++	status->state = ((state == SND_PCM_STATE_RUNNING) || (state == SND_PCM_STATE_STARTING)) ? dsnoop->state : state;
+ 	status->trigger_tstamp = dsnoop->trigger_tstamp;
+ 	status->avail = snd_pcm_mmap_capture_avail(pcm);
+ 	status->avail_max = status->avail > dsnoop->avail_max ? status->avail : dsnoop->avail_max;
+@@ -223,6 +224,7 @@ static int snd_pcm_dsnoop_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
+ 	switch(dsnoop->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		err = snd_pcm_dsnoop_sync_ptr(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -247,6 +249,7 @@ static int snd_pcm_dsnoop_hwsync(snd_pcm_t *pcm)
+ 	switch(dsnoop->state) {
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		return snd_pcm_dsnoop_sync_ptr(pcm);
+ 	case SNDRV_PCM_STATE_PREPARED:
+ 	case SNDRV_PCM_STATE_SUSPENDED:
+@@ -287,6 +290,21 @@ static int snd_pcm_dsnoop_start(snd_pcm_t *pcm)
+ 	return 0;
+ }
+ 
++int snd_pcm_dsnoop_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_direct_t *dsnoop = pcm->private_data;
++	int ret;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		ret = snd_pcm_start_at_system(dsnoop->spcm, audio_clock_type, start_time);
++	else
++		ret = snd_pcm_start_at_audio(dsnoop->spcm, audio_clock_type, start_time);
++
++	if(ret == 0)
++		dsnoop->state = SND_PCM_STATE_STARTING;
++}
++
++
+ static int snd_pcm_dsnoop_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_direct_t *dsnoop = pcm->private_data;
+@@ -308,7 +326,8 @@ static int snd_pcm_dsnoop_drain(snd_pcm_t *pcm)
+ 	stop_threshold = pcm->stop_threshold;
+ 	if (pcm->stop_threshold > pcm->buffer_size)
+ 		pcm->stop_threshold = pcm->buffer_size;
+-	while (dsnoop->state == SND_PCM_STATE_RUNNING) {
++	while (dsnoop->state == SND_PCM_STATE_RUNNING ||
++	        dsnoop->state == SND_PCM_STATE_STARTING) {
+ 		err = snd_pcm_dsnoop_sync_ptr(pcm);
+ 		if (err < 0)
+ 			break;
+@@ -405,7 +424,8 @@ static snd_pcm_sframes_t snd_pcm_dsnoop_mmap_commit(snd_pcm_t *pcm,
+ 	default:
+ 		break;
+ 	}
+-	if (dsnoop->state == SND_PCM_STATE_RUNNING) {
++	if (dsnoop->state == SND_PCM_STATE_RUNNING ||
++	    dsnoop->state == SND_PCM_STATE_STARTING) {
+ 		err = snd_pcm_dsnoop_sync_ptr(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -422,7 +442,8 @@ static snd_pcm_sframes_t snd_pcm_dsnoop_avail_update(snd_pcm_t *pcm)
+ 	snd_pcm_direct_t *dsnoop = pcm->private_data;
+ 	int err;
+ 	
+-	if (dsnoop->state == SND_PCM_STATE_RUNNING) {
++	if (dsnoop->state == SND_PCM_STATE_RUNNING ||
++	    dsnoop->state == SND_PCM_STATE_STARTING) {
+ 		err = snd_pcm_dsnoop_sync_ptr(pcm);
+ 		if (err < 0)
+ 			return err;
+@@ -440,7 +461,8 @@ static int snd_pcm_dsnoop_htimestamp(snd_pcm_t *pcm,
+ 	
+ 	while (1) {
+ 		if (dsnoop->state == SND_PCM_STATE_RUNNING ||
+-		    dsnoop->state == SND_PCM_STATE_DRAINING)
++		    dsnoop->state == SND_PCM_STATE_DRAINING ||
++		    dsnoop->state == SND_PCM_STATE_STARTING)
+ 			snd_pcm_dsnoop_sync_ptr(pcm);
+ 		avail1 = snd_pcm_mmap_capture_avail(pcm);
+ 		if (ok && *avail == avail1)
+@@ -491,6 +513,7 @@ static const snd_pcm_fast_ops_t snd_pcm_dsnoop_fast_ops = {
+ 	.prepare = snd_pcm_direct_prepare,
+ 	.reset = snd_pcm_dsnoop_reset,
+ 	.start = snd_pcm_dsnoop_start,
++	.start_at = snd_pcm_dsnoop_start_at,
+ 	.drop = snd_pcm_dsnoop_drop,
+ 	.drain = snd_pcm_dsnoop_drain,
+ 	.pause = snd_pcm_dsnoop_pause,
+diff --git a/src/pcm/pcm_file.c b/src/pcm/pcm_file.c
+index 92eb072..d7b6f91 100644
+--- a/src/pcm/pcm_file.c
++++ b/src/pcm/pcm_file.c
+@@ -669,6 +669,17 @@ static const snd_pcm_ops_t snd_pcm_file_ops = {
+ 	.set_chmap = snd_pcm_generic_set_chmap,
+ };
+ 
++int snd_pcm_file_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_generic_t *generic = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(generic->slave, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(generic->slave, audio_clock_type, start_time);
++}
++
++
+ static const snd_pcm_fast_ops_t snd_pcm_file_fast_ops = {
+ 	.status = snd_pcm_generic_status,
+ 	.state = snd_pcm_generic_state,
+@@ -677,6 +688,7 @@ static const snd_pcm_fast_ops_t snd_pcm_file_fast_ops = {
+ 	.prepare = snd_pcm_generic_prepare,
+ 	.reset = snd_pcm_file_reset,
+ 	.start = snd_pcm_generic_start,
++	.start_at = snd_pcm_file_start_at,
+ 	.drop = snd_pcm_file_drop,
+ 	.drain = snd_pcm_file_drain,
+ 	.pause = snd_pcm_generic_pause,
+diff --git a/src/pcm/pcm_hooks.c b/src/pcm/pcm_hooks.c
+index ce1cf36..827dce2 100644
+--- a/src/pcm/pcm_hooks.c
++++ b/src/pcm/pcm_hooks.c
+@@ -170,6 +170,16 @@ static const snd_pcm_ops_t snd_pcm_hooks_ops = {
+ 	.set_chmap = snd_pcm_generic_set_chmap,
+ };
+ 
++int snd_pcm_hook_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_generic_t *generic = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(generic->slave, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(generic->slave, audio_clock_type, start_time);
++}
++
+ static const snd_pcm_fast_ops_t snd_pcm_hooks_fast_ops = {
+ 	.status = snd_pcm_generic_status,
+ 	.state = snd_pcm_generic_state,
+@@ -178,6 +188,7 @@ static const snd_pcm_fast_ops_t snd_pcm_hooks_fast_ops = {
+ 	.prepare = snd_pcm_generic_prepare,
+ 	.reset = snd_pcm_generic_reset,
+ 	.start = snd_pcm_generic_start,
++	.start_at = snd_pcm_hook_start_at,
+ 	.drop = snd_pcm_generic_drop,
+ 	.drain = snd_pcm_generic_drain,
+ 	.pause = snd_pcm_generic_pause,
+diff --git a/src/pcm/pcm_hw.c b/src/pcm/pcm_hw.c
+index 4f4b84b..0842535 100644
+--- a/src/pcm/pcm_hw.c
++++ b/src/pcm/pcm_hw.c
+@@ -627,6 +627,25 @@ static int snd_pcm_hw_start(snd_pcm_t *pcm)
+ 	return 0;
+ }
+ 
++static int snd_pcm_hw_start_at(snd_pcm_t *pcm, int clock_class, int clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_hw_t *hw = pcm->private_data;
++	int err;
++
++	struct snd_startat startat_operation = {
++		.clock_class = clock_class,
++		.clock_type = clock_type,
++		.start_time = *start_time,
++	};
++
++	if (ioctl(hw->fd, SNDRV_PCM_IOCTL_START_AT, &startat_operation) < 0) {
++		err = -errno;
++		SYSMSG("SNDRV_PCM_IOCTL_START_AT failed (%i)", err);
++		return err;
++	}
++	return 0;
++}
++
+ static int snd_pcm_hw_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_hw_t *hw = pcm->private_data;
+@@ -714,6 +733,7 @@ static snd_pcm_sframes_t snd_pcm_hw_forward(snd_pcm_t *pcm, snd_pcm_uframes_t fr
+ 		case SNDRV_PCM_STATE_DRAINING:
+ 		case SNDRV_PCM_STATE_PAUSED:
+ 		case SNDRV_PCM_STATE_PREPARED:
++		case SNDRV_PCM_STATE_STARTING:
+ 			break;
+ 		case SNDRV_PCM_STATE_XRUN:
+ 			return -EPIPE;
+@@ -999,6 +1019,7 @@ static snd_pcm_sframes_t snd_pcm_hw_avail_update(snd_pcm_t *pcm)
+ 	avail = snd_pcm_mmap_avail(pcm);
+ 	switch (FAST_PCM_STATE(hw)) {
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 		if (avail >= pcm->stop_threshold) {
+ 			/* SNDRV_PCM_IOCTL_XRUN ioctl has been implemented since PCM kernel API 2.0.1 */
+ 			if (SNDRV_PROTOCOL_VERSION(2, 0, 1) <= hw->version) {
+@@ -1209,6 +1230,7 @@ static snd_pcm_chmap_t *snd_pcm_hw_get_chmap(snd_pcm_t *pcm)
+ 	switch (FAST_PCM_STATE(hw)) {
+ 	case SNDRV_PCM_STATE_PREPARED:
+ 	case SNDRV_PCM_STATE_RUNNING:
++	case SNDRV_PCM_STATE_STARTING:
+ 	case SNDRV_PCM_STATE_XRUN:
+ 	case SNDRV_PCM_STATE_DRAINING:
+ 	case SNDRV_PCM_STATE_PAUSED:
+@@ -1343,6 +1365,7 @@ static const snd_pcm_fast_ops_t snd_pcm_hw_fast_ops = {
+ 	.prepare = snd_pcm_hw_prepare,
+ 	.reset = snd_pcm_hw_reset,
+ 	.start = snd_pcm_hw_start,
++	.start_at = snd_pcm_hw_start_at,
+ 	.drop = snd_pcm_hw_drop,
+ 	.drain = snd_pcm_hw_drain,
+ 	.pause = snd_pcm_hw_pause,
+@@ -1374,6 +1397,7 @@ static const snd_pcm_fast_ops_t snd_pcm_hw_fast_ops_timer = {
+ 	.prepare = snd_pcm_hw_prepare,
+ 	.reset = snd_pcm_hw_reset,
+ 	.start = snd_pcm_hw_start,
++	.start_at = snd_pcm_hw_start_at,
+ 	.drop = snd_pcm_hw_drop,
+ 	.drain = snd_pcm_hw_drain,
+ 	.pause = snd_pcm_hw_pause,
+diff --git a/src/pcm/pcm_local.h b/src/pcm/pcm_local.h
+index 326618e..6851204 100644
+--- a/src/pcm/pcm_local.h
++++ b/src/pcm/pcm_local.h
+@@ -154,6 +154,7 @@ typedef struct {
+ 	int (*prepare)(snd_pcm_t *pcm);
+ 	int (*reset)(snd_pcm_t *pcm);
+ 	int (*start)(snd_pcm_t *pcm);
++	int (*start_at)(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time);
+ 	int (*drop)(snd_pcm_t *pcm);
+ 	int (*drain)(snd_pcm_t *pcm);
+ 	int (*pause)(snd_pcm_t *pcm, int enable);
+@@ -482,8 +483,10 @@ static inline snd_pcm_uframes_t snd_pcm_mmap_hw_rewindable(snd_pcm_t *pcm)
+ 
+ static inline const snd_pcm_channel_area_t *snd_pcm_mmap_areas(snd_pcm_t *pcm)
+ {
++	snd_pcm_state_t state = snd_pcm_state(pcm);
+ 	if (pcm->stopped_areas &&
+-	    snd_pcm_state(pcm) != SND_PCM_STATE_RUNNING) 
++	    state != SND_PCM_STATE_RUNNING &&
++	    state != SND_PCM_STATE_STARTING)
+ 		return pcm->stopped_areas;
+ 	return pcm->running_areas;
+ }
+diff --git a/src/pcm/pcm_meter.c b/src/pcm/pcm_meter.c
+index 1b0ccb4..4ee0c33 100644
+--- a/src/pcm/pcm_meter.c
++++ b/src/pcm/pcm_meter.c
+@@ -201,6 +201,7 @@ static void *snd_pcm_meter_thread(void *data)
+ 		err = snd_pcm_status(spcm, &status);
+ 		assert(err >= 0);
+ 		if (status.state != SND_PCM_STATE_RUNNING &&
++		    status.state != SND_PCM_STATE_STARTING &&
+ 		    (status.state != SND_PCM_STATE_DRAINING ||
+ 		     spcm->stream != SND_PCM_STREAM_PLAYBACK)) {
+ 			if (meter->running) {
+@@ -325,6 +326,16 @@ static int snd_pcm_meter_start(snd_pcm_t *pcm)
+ 	return err;
+ }
+ 
++int snd_pcm_meter_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_meter_t *meter = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(meter->gen.slave, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(meter->gen.slave, audio_clock_type, start_time);
++}
++
+ static snd_pcm_sframes_t snd_pcm_meter_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t frames)
+ {
+ 	snd_pcm_meter_t *meter = pcm->private_data;
+@@ -530,6 +541,7 @@ static const snd_pcm_fast_ops_t snd_pcm_meter_fast_ops = {
+ 	.prepare = snd_pcm_meter_prepare,
+ 	.reset = snd_pcm_meter_reset,
+ 	.start = snd_pcm_meter_start,
++	.start_at = snd_pcm_meter_start_at,
+ 	.drop = snd_pcm_generic_drop,
+ 	.drain = snd_pcm_generic_drain,
+ 	.pause = snd_pcm_generic_pause,
+diff --git a/src/pcm/pcm_mmap.c b/src/pcm/pcm_mmap.c
+index 5c4fbe1..caf4284 100644
+--- a/src/pcm/pcm_mmap.c
++++ b/src/pcm/pcm_mmap.c
+@@ -136,7 +136,7 @@ static snd_pcm_sframes_t snd_pcm_mmap_read_areas(snd_pcm_t *pcm,
+  * \param size frames to be written
+  * \return a positive number of frames actually written otherwise a
+  * negative error code
+- * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING)
++ * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING or #SND_PCM_STATE_STARTING)
+  * \retval -EPIPE an underrun occurred
+  * \retval -ESTRPIPE a suspend event occurred (stream is suspended and waiting for an application recovery)
+  *
+@@ -161,7 +161,7 @@ snd_pcm_sframes_t snd_pcm_mmap_writei(snd_pcm_t *pcm, const void *buffer, snd_pc
+  * \param size frames to be written
+  * \return a positive number of frames actually written otherwise a
+  * negative error code
+- * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING)
++ * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING or #SND_PCM_STATE_STARTING)
+  * \retval -EPIPE an underrun occurred
+  * \retval -ESTRPIPE a suspend event occurred (stream is suspended and waiting for an application recovery)
+  *
+@@ -186,7 +186,7 @@ snd_pcm_sframes_t snd_pcm_mmap_writen(snd_pcm_t *pcm, void **bufs, snd_pcm_ufram
+  * \param size frames to be written
+  * \return a positive number of frames actually read otherwise a
+  * negative error code
+- * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING)
++ * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING or #SND_PCM_STATE_STARTING)
+  * \retval -EPIPE an overrun occurred
+  * \retval -ESTRPIPE a suspend event occurred (stream is suspended and waiting for an application recovery)
+  *
+@@ -211,7 +211,7 @@ snd_pcm_sframes_t snd_pcm_mmap_readi(snd_pcm_t *pcm, void *buffer, snd_pcm_ufram
+  * \param size frames to be written
+  * \return a positive number of frames actually read otherwise a
+  * negative error code
+- * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING)
++ * \retval -EBADFD PCM is not in the right state (#SND_PCM_STATE_PREPARED or #SND_PCM_STATE_RUNNING or #SND_PCM_STATE_STARTING)
+  * \retval -EPIPE an overrun occurred
+  * \retval -ESTRPIPE a suspend event occurred (stream is suspended and waiting for an application recovery)
+  *
+diff --git a/src/pcm/pcm_multi.c b/src/pcm/pcm_multi.c
+index c4b1fba..161df1a 100644
+--- a/src/pcm/pcm_multi.c
++++ b/src/pcm/pcm_multi.c
+@@ -490,6 +490,30 @@ static int snd_pcm_multi_start(snd_pcm_t *pcm)
+ 	return err;
+ }
+ 
++static int snd_pcm_multi_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_multi_t *multi = pcm->private_data;
++	int err = 0;
++	unsigned int i;
++	if (multi->slaves[0].linked) {
++		if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++			return snd_pcm_start_at_system(multi->slaves[0].linked, audio_clock_type, start_time);
++		else
++			return snd_pcm_start_at_audio(multi->slaves[0].linked, audio_clock_type, start_time);
++		}
++		for (i = 0; i < multi->slaves_count; ++i) {
++			if (multi->slaves[i].linked)
++				continue;
++			if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++				err = snd_pcm_start_at_system(multi->slaves[i].pcm, audio_clock_type, start_time);
++			else
++				err = snd_pcm_start_at_audio(multi->slaves[i].pcm, audio_clock_type, start_time);
++			if (err < 0)
++				return err;
++			}
++		return err;
++}
++
+ static int snd_pcm_multi_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_multi_t *multi = pcm->private_data;
+@@ -963,6 +987,7 @@ static const snd_pcm_fast_ops_t snd_pcm_multi_fast_ops = {
+ 	.prepare = snd_pcm_multi_prepare,
+ 	.reset = snd_pcm_multi_reset,
+ 	.start = snd_pcm_multi_start,
++	.start_at = snd_pcm_multi_start_at,
+ 	.drop = snd_pcm_multi_drop,
+ 	.drain = snd_pcm_multi_drain,
+ 	.pause = snd_pcm_multi_pause,
+diff --git a/src/pcm/pcm_null.c b/src/pcm/pcm_null.c
+index 685618e..880655c 100644
+--- a/src/pcm/pcm_null.c
++++ b/src/pcm/pcm_null.c
+@@ -145,6 +145,16 @@ static int snd_pcm_null_start(snd_pcm_t *pcm)
+ 	return 0;
+ }
+ 
++int snd_pcm_null_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_null_t *null = pcm->private_data;
++	assert(null->state == SND_PCM_STATE_PREPARED);
++	assert(pcm->stream == SND_PCM_STREAM_PLAYBACK);
++	null->state = SND_PCM_STATE_STARTING;
++	*pcm->hw.ptr = *pcm->appl.ptr;
++	return 0;
++}
++
+ static int snd_pcm_null_drop(snd_pcm_t *pcm)
+ {
+ 	snd_pcm_null_t *null = pcm->private_data;
+@@ -192,6 +202,7 @@ static snd_pcm_sframes_t snd_pcm_null_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t f
+ 	snd_pcm_null_t *null = pcm->private_data;
+ 	switch (null->state) {
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		snd_pcm_mmap_hw_backward(pcm, frames);
+ 		/* Fall through */
+ 	case SND_PCM_STATE_PREPARED:
+@@ -207,6 +218,7 @@ static snd_pcm_sframes_t snd_pcm_null_forward(snd_pcm_t *pcm, snd_pcm_uframes_t
+ 	snd_pcm_null_t *null = pcm->private_data;
+ 	switch (null->state) {
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		snd_pcm_mmap_hw_forward(pcm, frames);
+ 		/* Fall through */
+ 	case SND_PCM_STATE_PREPARED:
+@@ -336,6 +348,7 @@ static const snd_pcm_fast_ops_t snd_pcm_null_fast_ops = {
+ 	.prepare = snd_pcm_null_prepare,
+ 	.reset = snd_pcm_null_reset,
+ 	.start = snd_pcm_null_start,
++	.start_at = snd_pcm_null_start_at,
+ 	.drop = snd_pcm_null_drop,
+ 	.drain = snd_pcm_null_drain,
+ 	.pause = snd_pcm_null_pause,
+diff --git a/src/pcm/pcm_plugin.c b/src/pcm/pcm_plugin.c
+index d007e8c..2c69060 100644
+--- a/src/pcm/pcm_plugin.c
++++ b/src/pcm/pcm_plugin.c
+@@ -540,6 +540,17 @@ static int snd_pcm_plugin_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ 	return 0;
+ }
+ 
++int snd_pcm_plug_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_generic_t *generic = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(generic->slave, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(generic->slave, audio_clock_type, start_time);
++}
++
++
+ const snd_pcm_fast_ops_t snd_pcm_plugin_fast_ops = {
+ 	.status = snd_pcm_plugin_status,
+ 	.state = snd_pcm_generic_state,
+@@ -548,6 +559,7 @@ const snd_pcm_fast_ops_t snd_pcm_plugin_fast_ops = {
+ 	.prepare = snd_pcm_plugin_prepare,
+ 	.reset = snd_pcm_plugin_reset,
+ 	.start = snd_pcm_generic_start,
++	.start_at = snd_pcm_plug_start_at,
+ 	.drop = snd_pcm_generic_drop,
+ 	.drain = snd_pcm_generic_drain,
+ 	.pause = snd_pcm_generic_pause,
+diff --git a/src/pcm/pcm_rate.c b/src/pcm/pcm_rate.c
+index 41bddac..ff94dab 100644
+--- a/src/pcm/pcm_rate.c
++++ b/src/pcm/pcm_rate.c
+@@ -1081,6 +1081,16 @@ static int snd_pcm_rate_start(snd_pcm_t *pcm)
+ 	return snd_pcm_start(rate->gen.slave);
+ }
+ 
++int snd_pcm_rate_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_rate_t *rate = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(rate->gen.slave, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(rate->gen.slave, audio_clock_type, start_time);
++}
++
+ static int snd_pcm_rate_status(snd_pcm_t *pcm, snd_pcm_status_t * status)
+ {
+ 	snd_pcm_rate_t *rate = pcm->private_data;
+@@ -1158,6 +1168,7 @@ static const snd_pcm_fast_ops_t snd_pcm_rate_fast_ops = {
+ 	.prepare = snd_pcm_rate_prepare,
+ 	.reset = snd_pcm_rate_reset,
+ 	.start = snd_pcm_rate_start,
++	.start_at = snd_pcm_rate_start_at,
+ 	.drop = snd_pcm_generic_drop,
+ 	.drain = snd_pcm_rate_drain,
+ 	.pause = snd_pcm_generic_pause,
+diff --git a/src/pcm/pcm_share.c b/src/pcm/pcm_share.c
+index 5d8aaf2..ecc052a 100644
+--- a/src/pcm/pcm_share.c
++++ b/src/pcm/pcm_share.c
+@@ -151,6 +151,7 @@ static snd_pcm_uframes_t _snd_pcm_share_slave_forward(snd_pcm_share_slave_t *sla
+ 		snd_pcm_t *pcm = share->pcm;
+ 		switch (share->state) {
+ 		case SND_PCM_STATE_RUNNING:
++		case SND_PCM_STATE_STARTING:
+ 			break;
+ 		case SND_PCM_STATE_DRAINING:
+ 			if (pcm->stream != SND_PCM_STREAM_PLAYBACK)
+@@ -163,7 +164,8 @@ static snd_pcm_uframes_t _snd_pcm_share_slave_forward(snd_pcm_share_slave_t *sla
+ 		frames = slave_avail - avail;
+ 		if (frames > max_frames)
+ 			max_frames = frames;
+-		if (share->state != SND_PCM_STATE_RUNNING)
++		if (share->state != SND_PCM_STATE_RUNNING &&
++		    share->state != SND_PCM_STATE_STARTING)
+ 			continue;
+ 		if (frames < min_frames)
+ 			min_frames = frames;
+@@ -208,6 +210,7 @@ static snd_pcm_uframes_t _snd_pcm_share_missing(snd_pcm_t *pcm)
+ 	// printf("state=%s hw_ptr=%ld appl_ptr=%ld slave appl_ptr=%ld safety=%ld silence=%ld\n", snd_pcm_state_name(share->state), slave->hw_ptr, share->appl_ptr, *slave->pcm->appl_ptr, slave->safety_threshold, slave->silence_frames);
+ 	switch (share->state) {
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		break;
+ 	case SND_PCM_STATE_DRAINING:
+ 		if (pcm->stream == SND_PCM_STREAM_PLAYBACK)
+@@ -264,6 +267,7 @@ static snd_pcm_uframes_t _snd_pcm_share_missing(snd_pcm_t *pcm)
+ 		}
+ 		break;
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		if (avail >= pcm->stop_threshold) {
+ 			_snd_pcm_share_stop(pcm, SND_PCM_STATE_XRUN);
+ 			break;
+@@ -696,12 +700,14 @@ static int snd_pcm_share_status(snd_pcm_t *pcm, snd_pcm_status_t *status)
+ 	if (pcm->stream == SND_PCM_STREAM_PLAYBACK) {
+ 		status->avail = snd_pcm_mmap_playback_avail(pcm);
+ 		if (share->state != SND_PCM_STATE_RUNNING &&
+-		    share->state != SND_PCM_STATE_DRAINING)
++		    share->state != SND_PCM_STATE_DRAINING &&
++		    share->state != SND_PCM_STATE_STARTING)
+ 			goto _notrunning;
+ 		d = pcm->buffer_size - status->avail;
+ 	} else {
+ 		status->avail = snd_pcm_mmap_capture_avail(pcm);
+-		if (share->state != SND_PCM_STATE_RUNNING)
++		if (share->state != SND_PCM_STATE_RUNNING &&
++		    share->state != SND_PCM_STATE_STARTING)
+ 			goto _notrunning;
+ 		d = status->avail;
+ 	}
+@@ -755,6 +761,7 @@ static int _snd_pcm_share_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
+ 	case SND_PCM_STATE_XRUN:
+ 		return -EPIPE;
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		break;
+ 	case SND_PCM_STATE_DRAINING:
+ 		if (pcm->stream == SND_PCM_STREAM_PLAYBACK)
+@@ -783,7 +790,8 @@ static snd_pcm_sframes_t snd_pcm_share_avail_update(snd_pcm_t *pcm)
+ 	snd_pcm_share_slave_t *slave = share->slave;
+ 	snd_pcm_sframes_t avail;
+ 	Pthread_mutex_lock(&slave->mutex);
+-	if (share->state == SND_PCM_STATE_RUNNING) {
++	if (share->state == SND_PCM_STATE_RUNNING ||
++	    share->state == SND_PCM_STATE_STARTING) {
+ 		avail = snd_pcm_avail_update(slave->pcm);
+ 		if (avail < 0) {
+ 			Pthread_mutex_unlock(&slave->mutex);
+@@ -821,7 +829,8 @@ static snd_pcm_sframes_t _snd_pcm_share_mmap_commit(snd_pcm_t *pcm,
+ 	snd_pcm_sframes_t ret;
+ 	snd_pcm_sframes_t frames;
+ 	if (pcm->stream == SND_PCM_STREAM_PLAYBACK &&
+-	    share->state == SND_PCM_STATE_RUNNING) {
++	    (share->state == SND_PCM_STATE_RUNNING ||
++	     share->state == SND_PCM_STATE_STARTING)) {
+ 		frames = *spcm->appl.ptr - share->appl_ptr;
+ 		if (frames > (snd_pcm_sframes_t)pcm->buffer_size)
+ 			frames -= pcm->boundary;
+@@ -835,7 +844,8 @@ static snd_pcm_sframes_t _snd_pcm_share_mmap_commit(snd_pcm_t *pcm,
+ 		}
+ 	}
+ 	snd_pcm_mmap_appl_forward(pcm, size);
+-	if (share->state == SND_PCM_STATE_RUNNING) {
++	if (share->state == SND_PCM_STATE_RUNNING ||
++	    share->state == SND_PCM_STATE_STARTING) {
+ 		frames = _snd_pcm_share_slave_forward(slave);
+ 		if (frames > 0) {
+ 			snd_pcm_sframes_t err;
+@@ -878,6 +888,7 @@ static int snd_pcm_share_prepare(snd_pcm_t *pcm)
+ 		err = -EBADFD;
+ 		goto _end;
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		err = -EBUSY;
+ 		goto _end;
+ 	case SND_PCM_STATE_PREPARED:
+@@ -980,6 +991,16 @@ static int snd_pcm_share_start(snd_pcm_t *pcm)
+ 	return err;
+ }
+ 
++int snd_pcm_share_start_at(snd_pcm_t *pcm, int clock_class, int audio_clock_type, const snd_htimestamp_t *start_time)
++{
++	snd_pcm_share_t *share = pcm->private_data;
++
++	if(clock_class == SNDRV_PCM_CLOCK_CLASS_SYSTEM)
++		return snd_pcm_start_at_system(share->slave->pcm, audio_clock_type, start_time);
++	else
++		return snd_pcm_start_at_audio(share->slave->pcm, audio_clock_type, start_time);
++}
++
+ static int snd_pcm_share_pause(snd_pcm_t *pcm ATTRIBUTE_UNUSED, int enable ATTRIBUTE_UNUSED)
+ {
+ 	return -ENOSYS;
+@@ -1010,6 +1031,7 @@ static snd_pcm_sframes_t _snd_pcm_share_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t
+ 	snd_pcm_sframes_t n;
+ 	switch (share->state) {
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		break;
+ 	case SND_PCM_STATE_PREPARED:
+ 		if (pcm->stream != SND_PCM_STREAM_PLAYBACK)
+@@ -1028,7 +1050,7 @@ static snd_pcm_sframes_t _snd_pcm_share_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t
+ 	assert(n >= 0);
+ 	if ((snd_pcm_uframes_t)n > frames)
+ 		frames = n;
+-	if (share->state == SND_PCM_STATE_RUNNING && frames > 0) {
++	if ((share->state == SND_PCM_STATE_RUNNING || share->state == SND_PCM_STATE_STARTING) && frames > 0) {
+ 		snd_pcm_sframes_t ret = snd_pcm_rewind(slave->pcm, frames);
+ 		if (ret < 0)
+ 			return ret;
+@@ -1068,6 +1090,7 @@ static snd_pcm_sframes_t _snd_pcm_share_forward(snd_pcm_t *pcm, snd_pcm_uframes_
+ 	snd_pcm_sframes_t n;
+ 	switch (share->state) {
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		break;
+ 	case SND_PCM_STATE_PREPARED:
+ 		if (pcm->stream != SND_PCM_STREAM_PLAYBACK)
+@@ -1085,7 +1108,7 @@ static snd_pcm_sframes_t _snd_pcm_share_forward(snd_pcm_t *pcm, snd_pcm_uframes_
+ 	n = snd_pcm_mmap_avail(pcm);
+ 	if ((snd_pcm_uframes_t)n > frames)
+ 		frames = n;
+-	if (share->state == SND_PCM_STATE_RUNNING && frames > 0) {
++	if ((share->state == SND_PCM_STATE_RUNNING || share->state == SND_PCM_STATE_STARTING) && frames > 0) {
+ 		snd_pcm_sframes_t ret = INTERNAL(snd_pcm_forward)(slave->pcm, frames);
+ 		if (ret < 0)
+ 			return ret;
+@@ -1179,6 +1202,7 @@ static int snd_pcm_share_drain(snd_pcm_t *pcm)
+ 			goto _end;
+ 		case SND_PCM_STATE_DRAINING:
+ 		case SND_PCM_STATE_RUNNING:
++		case SND_PCM_STATE_STARTING:
+ 			share->state = SND_PCM_STATE_DRAINING;
+ 			_snd_pcm_share_update(pcm);
+ 			Pthread_mutex_unlock(&slave->mutex);
+@@ -1231,6 +1255,7 @@ static int snd_pcm_share_drop(snd_pcm_t *pcm)
+ 		}
+ 		/* Fall through */
+ 	case SND_PCM_STATE_RUNNING:
++	case SND_PCM_STATE_STARTING:
+ 		_snd_pcm_share_stop(pcm, SND_PCM_STATE_SETUP);
+ 		_snd_pcm_share_update(pcm);
+ 		break;
+@@ -1331,6 +1356,7 @@ static const snd_pcm_fast_ops_t snd_pcm_share_fast_ops = {
+ 	.prepare = snd_pcm_share_prepare,
+ 	.reset = snd_pcm_share_reset,
+ 	.start = snd_pcm_share_start,
++	.start_at = snd_pcm_share_start_at,
+ 	.drop = snd_pcm_share_drop,
+ 	.drain = snd_pcm_share_drain,
+ 	.pause = snd_pcm_share_pause,
+diff --git a/test/pcm.c b/test/pcm.c
+index 18b6176..6c491fc 100644
+--- a/test/pcm.c
++++ b/test/pcm.c
+@@ -300,6 +300,7 @@ static int write_and_poll_loop(snd_pcm_t *handle,
+ 	double phase = 0;
+ 	signed short *ptr;
+ 	int err, count, cptr, init;
++	snd_pcm_state_t state;
+ 
+ 	count = snd_pcm_poll_descriptors_count (handle);
+ 	if (count <= 0) {
+@@ -350,7 +351,9 @@ static int write_and_poll_loop(snd_pcm_t *handle,
+ 				init = 1;
+ 				break;	/* skip one period */
+ 			}
+-			if (snd_pcm_state(handle) == SND_PCM_STATE_RUNNING)
++			state = snd_pcm_state(handle);
++			if (state == SND_PCM_STATE_RUNNING ||
++			    state == SND_PCM_STATE_STARTING)
+ 				init = 0;
+ 			ptr += err * channels;
+ 			cptr -= err;
+-- 
+2.6.2
+

--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -221,6 +221,7 @@ define GstBuildLibrary
 endef
 
 $(eval $(call GstBuildLibrary,allocators,allocators,,))
+$(eval $(call GstBuildLibrary,alsaclock,alsaclock,,+alsa-lib,))
 $(eval $(call GstBuildLibrary,app,app,,))
 $(eval $(call GstBuildLibrary,audio,audio,tag,))
 $(eval $(call GstBuildLibrary,fft,FFT,,))

--- a/multimedia/gst1-plugins-base/patches/004-Synchronize-playback-support-using-alsa-start-at.patch
+++ b/multimedia/gst1-plugins-base/patches/004-Synchronize-playback-support-using-alsa-start-at.patch
@@ -1,0 +1,932 @@
+From 7b497527256a20f0f3295327f17366a4408e668d Mon Sep 17 00:00:00 2001
+From: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+Date: Fri, 2 Dec 2016 15:15:34 +0530
+Subject: [PATCH 1/2] Synchronize playback support using alsa start-at
+
+Add gstalsaclock library that implements a custom GstClock that uses
+pcm driver interface to read high-precision audio hardware clock
+timestamps.
+
+Add property 'start-at' in alsasink for additional delay
+of the sink in nanoseconds to sync playback start in hardware.
+
+Change-Id: I8563d2149426a835a3590c10cd0d25299c9bf269
+Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+Signed-off-by: Matin Momin <Matin.Momin@imgtec.com>
+Signed-off-by: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+---
+ configure.ac                                       |   8 +-
+ ext/alsa/gstalsasink.c                             | 178 +++++++++++++++-
+ ext/alsa/gstalsasink.h                             |   3 +
+ gst-libs/Makefile.am                               |   3 +-
+ gst-libs/ext/Makefile.am                           |   9 +
+ gst-libs/ext/alsaclock/Makefile.am                 |  20 ++
+ gst-libs/ext/alsaclock/gstalsaclock.c              | 232 +++++++++++++++++++++
+ gst-libs/ext/alsaclock/gstalsaclock.h              |  76 +++++++
+ gst-libs/gst/audio/gstaudiobasesink.c              |  39 +++-
+ gst-libs/gst/audio/gstaudiobasesink.h              |   5 +
+ pkgconfig/Makefile.am                              |   3 +
+ pkgconfig/gstreamer-alsaclock-uninstalled.pc.in    |  13 ++
+ pkgconfig/gstreamer-alsaclock.pc.in                |  11 +
+ pkgconfig/gstreamer-plugins-base-uninstalled.pc.in |   4 +-
+ pkgconfig/gstreamer-plugins-base.pc.in             |   2 +-
+ 15 files changed, 596 insertions(+), 10 deletions(-)
+ create mode 100644 gst-libs/ext/Makefile.am
+ create mode 100644 gst-libs/ext/alsaclock/Makefile.am
+ create mode 100644 gst-libs/ext/alsaclock/gstalsaclock.c
+ create mode 100644 gst-libs/ext/alsaclock/gstalsaclock.h
+ create mode 100644 pkgconfig/gstreamer-alsaclock-uninstalled.pc.in
+ create mode 100644 pkgconfig/gstreamer-alsaclock.pc.in
+
+diff --git a/configure.ac b/configure.ac
+index a18f1c8..a26160b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -587,12 +587,12 @@ echo
+ dnl *** alsa ***
+ translit(dnm, m, l) AM_CONDITIONAL(USE_ALSA, true)
+ AG_GST_CHECK_FEATURE(ALSA, [ALSA], alsa, [
+-  PKG_CHECK_MODULES(ALSA, alsa >= 0.9.1, [
++  PKG_CHECK_MODULES(ALSA, alsa >= 1.0.29, [
+     HAVE_ALSA="yes"
+     AC_SUBST(ALSA_CFLAGS)
+     AC_SUBST(ALSA_LIBS)
+   ], [
+-    AM_PATH_ALSA(0.9.1, HAVE_ALSA="yes", HAVE_ALSA="no")
++    AM_PATH_ALSA(1.0.29, HAVE_ALSA="yes", HAVE_ALSA="no")
+   ])
+ ])
+ 
+@@ -868,6 +868,8 @@ ext/pango/Makefile
+ ext/theora/Makefile
+ ext/vorbis/Makefile
+ gst-libs/Makefile
++gst-libs/ext/Makefile
++gst-libs/ext/alsaclock/Makefile
+ gst-libs/gst/Makefile
+ gst-libs/gst/allocators/Makefile
+ gst-libs/gst/audio/Makefile
+@@ -885,6 +887,8 @@ tools/Makefile
+ pkgconfig/Makefile
+ pkgconfig/gstreamer-allocators.pc
+ pkgconfig/gstreamer-allocators-uninstalled.pc
++pkgconfig/gstreamer-alsaclock.pc
++pkgconfig/gstreamer-alsaclock-uninstalled.pc
+ pkgconfig/gstreamer-audio.pc
+ pkgconfig/gstreamer-audio-uninstalled.pc
+ pkgconfig/gstreamer-app.pc
+diff --git a/ext/alsa/gstalsasink.c b/ext/alsa/gstalsasink.c
+index 28f328e..410f703 100644
+--- a/ext/alsa/gstalsasink.c
++++ b/ext/alsa/gstalsasink.c
+@@ -43,6 +43,7 @@
+ #include <unistd.h>
+ #include <string.h>
+ #include <getopt.h>
++#include <limits.h>
+ #include <alsa/asoundlib.h>
+ 
+ #include "gstalsa.h"
+@@ -61,6 +62,7 @@
+ #define DEFAULT_CARD_NAME	""
+ #define SPDIF_PERIOD_SIZE 1536
+ #define SPDIF_BUFFER_SIZE 15360
++#define MAX_START_AT 7000000000
+ 
+ enum
+ {
+@@ -68,6 +70,8 @@ enum
+   PROP_DEVICE,
+   PROP_DEVICE_NAME,
+   PROP_CARD_NAME,
++  PROP_START_AT,
++  PROP_START_AT_SLAVE,
+   PROP_LAST
+ };
+ 
+@@ -97,6 +101,8 @@ static void gst_alsasink_reset (GstAudioSink * asink);
+ static gboolean gst_alsasink_acceptcaps (GstAlsaSink * alsa, GstCaps * caps);
+ static GstBuffer *gst_alsasink_payload (GstAudioBaseSink * sink,
+     GstBuffer * buf);
++static gboolean gst_alsasink_setup_render (GstAudioBaseSink * sink,
++    GstBuffer * buf);
+ 
+ static gint output_ref;         /* 0    */
+ static snd_output_t *output;    /* NULL */
+@@ -173,6 +179,8 @@ gst_alsasink_class_init (GstAlsaSinkClass * klass)
+   gstbasesink_class->query = GST_DEBUG_FUNCPTR (gst_alsasink_query);
+ 
+   gstbaseaudiosink_class->payload = GST_DEBUG_FUNCPTR (gst_alsasink_payload);
++  gstbaseaudiosink_class->setup_render =
++      GST_DEBUG_FUNCPTR (gst_alsasink_setup_render);
+ 
+   gstaudiosink_class->open = GST_DEBUG_FUNCPTR (gst_alsasink_open);
+   gstaudiosink_class->prepare = GST_DEBUG_FUNCPTR (gst_alsasink_prepare);
+@@ -196,6 +204,20 @@ gst_alsasink_class_init (GstAlsaSinkClass * klass)
+       g_param_spec_string ("card-name", "Card name",
+           "Human-readable name of the sound card", DEFAULT_CARD_NAME,
+           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
++
++  g_object_class_install_property (gobject_class, PROP_START_AT,
++      g_param_spec_uint64 ("start-at", "Start at",
++          "Additional delay of the sink in nanoseconds to sync the playback "
++          "start in hardware (0 = disabled, sets slave-method property "
++          "to GST_AUDIO_BASE_SINK_SLAVE_NONE)",
++          0, MAX_START_AT, 0, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
++
++  g_object_class_install_property (gobject_class, PROP_START_AT_SLAVE,
++      g_param_spec_boolean ("start-at-slave", "Start at slave mode",
++          "Based on this, sink decide how to interpret the buffer pts value"
++          "For slave buffer PTS is absolute pts so base_time addition is"
++          "not required", FALSE,
++          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+ }
+ 
+ static void
+@@ -203,8 +225,10 @@ gst_alsasink_set_property (GObject * object, guint prop_id,
+     const GValue * value, GParamSpec * pspec)
+ {
+   GstAlsaSink *sink;
++  GstAudioBaseSink *basesink;
+ 
+   sink = GST_ALSA_SINK (object);
++  basesink = GST_AUDIO_BASE_SINK (object);
+ 
+   switch (prop_id) {
+     case PROP_DEVICE:
+@@ -215,6 +239,21 @@ gst_alsasink_set_property (GObject * object, guint prop_id,
+         sink->device = g_strdup (DEFAULT_DEVICE);
+       }
+       break;
++    case PROP_START_AT:
++      /* setting 'slave-method' property to GST_AUDIO_BASE_SINK_SLAVE_NONE,
++       * as to use 'start-at' property, internal audio clock has to be
++       * overridden with either GstSystemClock or GstAlsaClock. */
++      gst_audio_base_sink_set_slave_method (basesink,
++          GST_AUDIO_BASE_SINK_SLAVE_NONE);
++      /* Drop late data to ensure sync playback. The gap caused by late
++       * data will be filled by silence. */
++      gst_audio_base_sink_set_drop_on_late (basesink,
++          TRUE);
++      sink->start_at = g_value_get_uint64 (value);
++      break;
++    case PROP_START_AT_SLAVE:
++      sink->start_at_slave = g_value_get_boolean (value);
++      break;
+     default:
+       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+       break;
+@@ -243,6 +282,9 @@ gst_alsasink_get_property (GObject * object, guint prop_id,
+           gst_alsa_find_card_name (GST_OBJECT_CAST (sink),
+               sink->device, SND_PCM_STREAM_PLAYBACK));
+       break;
++    case PROP_START_AT:
++      g_value_set_uint64 (value, sink->start_at);
++      break;
+     default:
+       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+       break;
+@@ -436,7 +478,17 @@ set_hwparams (GstAlsaSink * alsa)
+   /* start with requested values, if we cannot configure alsa for those values,
+    * we set these values to -1, which will leave the default alsa values */
+   buffer_time = alsa->buffer_time;
+-  period_time = alsa->period_time;
++  if (alsa->start_at) {
++    /* For start_at based playback double the period time. With doubled
++     * period time, probablity of bug where master and slave play
++     * out of sync in multiples of 10msec is reduced considerably.
++     * Currently we don't know the reason for this behaviour.
++     * TODO(matin.momin) This is a HACK. Fix this issue properly.
++     */
++    period_time = alsa->period_time * 2;
++  } else {
++    period_time = alsa->period_time;
++  }
+ 
+ retry:
+   /* choose all parameters */
+@@ -921,6 +973,16 @@ gst_alsasink_prepare (GstAudioSink * asink, GstAudioRingBufferSpec * spec)
+   }
+ #endif /* SND_CHMAP_API_VERSION */
+ 
++  if (alsa->start_at != 0) {
++    /* filling period_size bytes with zero samples to satisfy start_at precondition */
++    gpointer zero_buffer;
++    gint length;
++    length = (alsa->bpf * alsa->channels * alsa->period_size);
++    zero_buffer = g_malloc0 (length);
++    gst_alsasink_write (asink, zero_buffer, length);
++    g_free (zero_buffer);
++  }
++
+   return TRUE;
+ 
+   /* ERRORS */
+@@ -1182,3 +1244,117 @@ gst_alsasink_payload (GstAudioBaseSink * sink, GstBuffer * buf)
+ 
+   return gst_buffer_ref (buf);
+ }
++
++static gboolean
++set_long_max_start_threshold (GstAlsaSink *alsa)
++{
++  snd_pcm_sw_params_t *params;
++  gint ret = FALSE;
++  gint err;
++
++  snd_pcm_sw_params_malloc (&params);
++
++  /* get the current swparams */
++  if ((err = snd_pcm_sw_params_current (alsa->handle, params)) < 0) {
++    GST_WARNING_OBJECT (alsa, "Error %d (%s) calling snd_pcm_sw_params_current",
++        err, snd_strerror (err));
++    goto failed;
++  }
++
++  /* for start-at based playback start the transfer when start-at */
++  /* time is reached. Hence set threshold to a very large value. */
++  if ((err = snd_pcm_sw_params_set_start_threshold (alsa->handle, params, LONG_MAX)) < 0) {
++    GST_WARNING_OBJECT (alsa, "Error %d (%s) calling snd_pcm_sw_params_set_start_threshold",
++        err, snd_strerror (err));
++    goto failed;
++  }
++
++  /* write the parameters to the playback device */
++  if ((err = snd_pcm_sw_params (alsa->handle, params)) < 0) {
++    GST_WARNING_OBJECT (alsa, "Error %d (%s) calling snd_pcm_sw_params",
++        err, snd_strerror (err));
++    goto failed;
++  }
++
++  ret = TRUE;
++
++failed:
++  snd_pcm_sw_params_free (params);
++
++  return ret;
++}
++
++static gboolean
++gst_alsasink_setup_render (GstAudioBaseSink * sink, GstBuffer * buf)
++{
++  GstAlsaSink *alsa;
++  GstBaseSink *bsink;
++
++  alsa = GST_ALSA_SINK (sink);
++  bsink = GST_BASE_SINK (alsa);
++
++  if (alsa->start_at != 0) {
++    const gchar *current_clock_type;
++    GstClockTime pts = 0;
++    GstClockTime start_pts = 0;
++    GstClockTime render_time = 0;
++    snd_htimestamp_t start_at;
++    GstSegment *segment = &bsink->segment;
++
++    pts = GST_BUFFER_PTS (buf);
++
++    if(alsa->start_at_slave) {
++      render_time = pts;
++    } else {
++      GstClockTime rt = gst_segment_to_running_time (segment, segment->format,
++                                                      pts);
++      render_time = GST_ELEMENT_CAST (sink)->base_time + rt;
++    }
++
++    start_pts = render_time + alsa->start_at;
++    GST_TIME_TO_TIMESPEC (start_pts, start_at);
++
++    /* start at can be set only if alsa is in prepared state and minimum
++     * buffer is queued. */
++    if (snd_pcm_state (alsa->handle) == SND_PCM_STATE_PREPARED
++        && (alsa->buffer_size - snd_pcm_avail (alsa->handle))
++        >= (2 * alsa->period_size)) {
++      GstClock *clock = gst_element_get_clock (GST_ELEMENT_CAST (sink));
++      GstClockTime now = gst_clock_get_time (clock);
++
++#ifndef GST_DISABLE_GST_DEBUG
++      GST_DEBUG_OBJECT (alsa, "buf_pts: %" G_GUINT64_FORMAT "start_at: %"
++                          G_GUINT64_FORMAT "now: %" G_GUINT64_FORMAT,
++                          GST_BUFFER_PTS (buf), start_pts, now);
++#endif
++      current_clock_type = G_OBJECT_TYPE_NAME (clock);
++      gst_object_unref(clock);
++
++      if (start_pts <= now) {
++        GST_DEBUG_OBJECT(alsa, "Buffer start_at PTS <= now, dropping buffer");
++        return FALSE;
++      }
++
++      if (!set_long_max_start_threshold (alsa)) {
++        GST_DEBUG_OBJECT (alsa, "failed to set LONG_MAX start threshold");
++        goto failed;
++      }
++
++      if (g_strcmp0 (current_clock_type, "GstAlsaClock") == 0) {
++        if (snd_pcm_start_at_audio (alsa->handle,
++                SND_PCM_AUDIO_TSTAMP_TYPE_COMPAT, &start_at) != 0)
++          goto failed;
++      } else if (g_strcmp0 (current_clock_type, "GstSystemClock") == 0) {
++        if (snd_pcm_start_at_system (alsa->handle,
++                SND_PCM_AUDIO_TSTAMP_TYPE_COMPAT, &start_at) != 0)
++          goto failed;
++      } else
++        goto failed;
++    }
++  }
++  return TRUE;
++
++failed:
++  GST_ELEMENT_ERROR (alsa, LIBRARY, FAILED, (NULL), ("failed to set start_at"));
++  return FALSE;
++}
+diff --git a/ext/alsa/gstalsasink.h b/ext/alsa/gstalsasink.h
+index 8c4c1b0..5156948 100644
+--- a/ext/alsa/gstalsasink.h
++++ b/ext/alsa/gstalsasink.h
+@@ -57,6 +57,9 @@ struct _GstAlsaSink {
+ 
+   gchar                 *device;
+ 
++  guint64               start_at;
++  gboolean              start_at_slave;
++
+   snd_pcm_t             *handle;
+   snd_pcm_hw_params_t   *hwparams;
+   snd_pcm_sw_params_t   *swparams;
+diff --git a/gst-libs/Makefile.am b/gst-libs/Makefile.am
+index 062cb55..1735517 100644
+--- a/gst-libs/Makefile.am
++++ b/gst-libs/Makefile.am
+@@ -1 +1,2 @@
+-SUBDIRS = gst
++SUBDIRS = gst \
++	  ext
+diff --git a/gst-libs/ext/Makefile.am b/gst-libs/ext/Makefile.am
+new file mode 100644
+index 0000000..eeb922d
+--- /dev/null
++++ b/gst-libs/ext/Makefile.am
+@@ -0,0 +1,9 @@
++if USE_ALSA
++ALSACLOCK_DIR=alsaclock
++else
++ALSACLOCK_DIR=
++endif
++
++SUBDIRS = $(ALSACLOCK_DIR)
++
++DIST_SUBDIRS = alsaclock
+\ No newline at end of file
+diff --git a/gst-libs/ext/alsaclock/Makefile.am b/gst-libs/ext/alsaclock/Makefile.am
+new file mode 100644
+index 0000000..34d53b1
+--- /dev/null
++++ b/gst-libs/ext/alsaclock/Makefile.am
+@@ -0,0 +1,20 @@
++lib_LTLIBRARIES = \
++	libgstalsaclock-@GST_API_VERSION@.la
++
++libgstalsaclock_@GST_API_VERSION@_la_SOURCES = \
++	gstalsaclock.c
++
++libgstalsaclock_@GST_API_VERSION@includedir = $(includedir)/gstreamer-@GST_API_VERSION@/ext/alsaclock
++libgstalsaclock_@GST_API_VERSION@include_HEADERS = \
++	gstalsaclock.h
++
++libgstalsaclock__@GST_API_VERSION@_la_CFLAGS = $(GST_CFLAGS) $(GLIB_CFLAGS) $(ALSA_CFLAGS)
++
++libgstalsaclock_@GST_API_VERSION@_la_CFLAGS = $(GST_PLUGINS_BASE_CFLAGS) $(GST_BASE_CFLAGS) \
++	$(GST_CFLAGS) $(ALSA_CFLAGS)
++libgstalsaclock_@GST_API_VERSION@_la_LIBADD = $(GST_PLUGINS_BASE_LIBS) $(GST_BASE_LIBS) \
++	$(GST_LIBS) $(ALSA_LIBS)
++libgstalsaclock_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS) \
++	$(GST_LT_LDFLAGS)
++
++include $(top_srcdir)/common/gst-glib-gen.mak
+diff --git a/gst-libs/ext/alsaclock/gstalsaclock.c b/gst-libs/ext/alsaclock/gstalsaclock.c
+new file mode 100644
+index 0000000..abd0aef
+--- /dev/null
++++ b/gst-libs/ext/alsaclock/gstalsaclock.c
+@@ -0,0 +1,232 @@
++/* GStreamer
++ * Copyright (C) 2015 Imagination Technologies
++ *
++ * gstalsaclock.c:
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++/**
++ * SECTION:gstalsaclock
++ *
++ * @short_description: Special clock that uses pcm driver interface to read
++                       high-precision audio hardware clock timestamps.
++ *
++ * #GstAlsaClock implements a custom #GstClock that uses pcm driver interface
++   to read high-precision audio hardware clock timestamps.
++ *
++ * A new clock is created with gst_alsa_clock_new() which takes the name and
++ * control element identifier ASCII string.
++ *
++ * A #GstAlsaClock is typically set on a #GstPipeline with
++ * gst_pipeline_use_clock().
++ */
++#include "gstalsaclock.h"
++#include <gst/audio/gstaudioclock.h>
++#include <alsa/asoundlib.h>
++
++
++GST_DEBUG_CATEGORY_STATIC (alsa_clock_debug);
++#define GST_CAT_DEFAULT alsa_clock_debug
++
++#define _do_init \
++    GST_DEBUG_CATEGORY_INIT (alsa_clock_debug, "alsaclock", 0, "alsaclock");
++#define gst_alsa_clock_parent_class parent_class
++G_DEFINE_TYPE_WITH_CODE (GstAlsaClock, gst_alsa_clock,
++    GST_TYPE_CLOCK, _do_init);
++
++struct _GstAlsaClockPrivate
++{
++  snd_ctl_elem_info_t *control_info;
++  snd_ctl_elem_id_t *control_id;
++  snd_ctl_elem_value_t *control_value;
++  snd_hctl_t *control_hctl;
++  snd_hctl_elem_t *control_elem;
++};
++
++#define GST_ALSA_CLOCK_GET_PRIVATE(obj)  \
++   (G_TYPE_INSTANCE_GET_PRIVATE ((obj), GST_TYPE_ALSA_CLOCK, \
++        GstAlsaClockPrivate))
++
++static void gst_alsa_clock_finalize (GObject * object);
++static GstClockTime gst_alsa_clock_get_internal_time (GstClock * clock);
++
++static gboolean
++prepare (GstAlsaClock * alsa_clock, const gchar * control_device,
++    const gchar * control_id)
++{
++  snd_ctl_t *control_handle = NULL;
++  gint err;
++
++  alsa_clock->priv->control_hctl = NULL;
++
++  if ((err =
++          snd_ctl_ascii_elem_id_parse (alsa_clock->priv->control_id,
++              control_id)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock,
++        "Invalid control identifier: %s, failed to parse: %s, prepare failed.",
++        control_id, snd_strerror (err));
++    goto error;
++  }
++
++  if ((err = snd_ctl_open (&control_handle, control_device, 0)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock,
++        "Cannot open control device %s: %s, prepare failed.", control_device,
++        snd_strerror (err));
++    goto error;
++  }
++
++  snd_ctl_elem_info_set_id (alsa_clock->priv->control_info,
++      alsa_clock->priv->control_id);
++  if ((err =
++          snd_ctl_elem_info (control_handle,
++              alsa_clock->priv->control_info)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock,
++        "Cannot get control element information: %s, prepare failed.",
++        snd_strerror (err));
++    goto error;
++  }
++
++  snd_ctl_close (control_handle);
++  control_handle = NULL;
++
++  snd_ctl_elem_info_get_id (alsa_clock->priv->control_info,
++      alsa_clock->priv->control_id);
++
++  if ((err =
++          snd_hctl_open (&alsa_clock->priv->control_hctl, control_device,
++              0)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock,
++        "Cannot open HCTL control device %s: %s, prepare failed.",
++        control_device, snd_strerror (err));
++    goto error;
++  }
++
++  if ((err = snd_hctl_load (alsa_clock->priv->control_hctl)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock, "Cannot load HCTL: %s, prepare failed.",
++        snd_strerror (err));
++    goto error;
++  }
++
++  alsa_clock->priv->control_elem =
++      snd_hctl_find_elem (alsa_clock->priv->control_hctl,
++      alsa_clock->priv->control_id);
++  if (!alsa_clock->priv->control_elem) {
++    GST_ERROR_OBJECT (alsa_clock,
++        "Cannot find HCTL element: %s, prepare failed.", snd_strerror (err));
++    goto error;
++  }
++
++  return TRUE;
++
++error:
++  if (control_handle)
++    snd_ctl_close (control_handle);
++
++  if (alsa_clock->priv->control_hctl)
++    snd_hctl_close (alsa_clock->priv->control_hctl);
++
++  return FALSE;
++}
++
++static void
++gst_alsa_clock_class_init (GstAlsaClockClass * klass)
++{
++  GObjectClass *gobject_class;
++  GstClockClass *gstclock_class;
++
++  gobject_class = (GObjectClass *) klass;
++  gstclock_class = (GstClockClass *) klass;
++
++  g_type_class_add_private (klass, sizeof (GstAlsaClockPrivate));
++
++  gobject_class->finalize = gst_alsa_clock_finalize;
++
++  gstclock_class->get_internal_time = gst_alsa_clock_get_internal_time;
++}
++
++static void
++gst_alsa_clock_init (GstAlsaClock * clock)
++{
++  GST_OBJECT_FLAG_SET (clock, GST_CLOCK_FLAG_CAN_SET_MASTER);
++
++  clock->priv = GST_ALSA_CLOCK_GET_PRIVATE (clock);
++
++  snd_ctl_elem_info_malloc (&clock->priv->control_info);
++  snd_ctl_elem_id_malloc (&clock->priv->control_id);
++  snd_ctl_elem_value_malloc (&clock->priv->control_value);
++}
++
++static void
++gst_alsa_clock_finalize (GObject * object)
++{
++  GstAlsaClock *self = GST_ALSA_CLOCK (object);
++
++  if (self->priv->control_hctl)
++    snd_hctl_close (self->priv->control_hctl);
++
++  /* Free resources */
++  if (self->priv->control_info)
++    snd_ctl_elem_info_free (self->priv->control_info);
++
++  if (self->priv->control_id)
++    snd_ctl_elem_id_free (self->priv->control_id);
++
++  if (self->priv->control_value)
++    snd_ctl_elem_value_free (self->priv->control_value);
++
++  G_OBJECT_CLASS (parent_class)->finalize (object);
++}
++
++static GstClockTime
++gst_alsa_clock_get_internal_time (GstClock * clock)
++{
++  struct timespec ts;
++  gint err;
++  GstAlsaClock *alsa_clock = GST_ALSA_CLOCK_CAST (clock);
++
++  if ((err = snd_hctl_elem_read (alsa_clock->priv->control_elem,
++              alsa_clock->priv->control_value)) != 0) {
++    GST_ERROR_OBJECT (alsa_clock, "Cannot read HCTL element value: %s",
++        snd_strerror (err));
++    return GST_CLOCK_TIME_NONE;
++  }
++
++  ts.tv_sec =
++      snd_ctl_elem_value_get_integer64 (alsa_clock->priv->control_value, 0);
++  ts.tv_nsec =
++      snd_ctl_elem_value_get_integer64 (alsa_clock->priv->control_value, 1);
++
++  return GST_TIMESPEC_TO_TIME (ts);
++}
++
++GstClock *
++gst_alsa_clock_new (const gchar * name, const gchar * control_device,
++    const gchar * control_id)
++{
++  GstAlsaClock *alsa_clock =
++      g_object_new (GST_TYPE_ALSA_CLOCK, "name", name, NULL);
++
++  if (!prepare (alsa_clock, control_device, control_id)) {
++    goto prepare_failed;
++  }
++
++  return GST_CLOCK (alsa_clock);
++
++prepare_failed:
++  gst_object_unref (alsa_clock);
++  return NULL;
++}
+diff --git a/gst-libs/ext/alsaclock/gstalsaclock.h b/gst-libs/ext/alsaclock/gstalsaclock.h
+new file mode 100644
+index 0000000..bb18ab7
+--- /dev/null
++++ b/gst-libs/ext/alsaclock/gstalsaclock.h
+@@ -0,0 +1,76 @@
++/* GStreamer
++ * Copyright (C)  2015 Imagination Technologies
++ *
++ * gstalsaclock.h:
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++
++#ifndef __GST_ALSA_CLOCK_H__
++#define __GST_ALSA_CLOCK_H__
++
++#include <gst/gst.h>
++#include <gst/gstclock.h>
++
++G_BEGIN_DECLS
++
++#define GST_TYPE_ALSA_CLOCK \
++  (gst_alsa_clock_get_type ())
++#define GST_ALSA_CLOCK(obj) \
++  (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_ALSA_CLOCK, GstAlsaClock))
++#define GST_ALSA_CLOCK_CAST(obj) \
++  ((GstAlsaClock *)(obj))
++#define GST_IS_ALSA_CLOCK(obj) \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_ALSA_CLOCK))
++#define GST_ALSA_CLOCK_CLASS(klass) \
++  (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_ALSA_CLOCK, GstAlsaClockClass))
++#define GST_IS_ALSA_CLOCK_CLASS(klass) \
++  (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_ALSA_CLOCK))
++
++typedef struct _GstAlsaClock GstAlsaClock;
++typedef struct _GstAlsaClockClass GstAlsaClockClass;
++typedef struct _GstAlsaClockPrivate GstAlsaClockPrivate;
++
++/**
++ * GstAlsaClock:
++ *
++ * Implementation of a #GstClock that uses the alsa time.
++ */
++struct _GstAlsaClock {
++  GstSystemClock       clock;
++
++  /*< private >*/
++  GstAlsaClockPrivate *priv;
++
++  gpointer _gst_reserved[GST_PADDING];
++};
++
++struct _GstAlsaClockClass {
++  GstSystemClockClass parent_class;
++
++  gpointer _gst_reserved[GST_PADDING];
++};
++
++GType                   gst_alsa_clock_get_type       (void);
++
++GstClock*               gst_alsa_clock_new            (const gchar * name,
++                                                       const gchar * control_device,
++                                                       const gchar * control_id);
++
++G_END_DECLS
++
++#endif /* __GST_ALSA_CLOCK_H__ */
+diff --git a/gst-libs/gst/audio/gstaudiobasesink.c b/gst-libs/gst/audio/gstaudiobasesink.c
+index 62fab35..89329e0 100644
+--- a/gst-libs/gst/audio/gstaudiobasesink.c
++++ b/gst-libs/gst/audio/gstaudiobasesink.c
+@@ -74,6 +74,9 @@ struct _GstAudioBaseSinkPrivate
+   GstAudioBaseSinkCustomSlavingCallback custom_slaving_callback;
+   gpointer custom_slaving_cb_data;
+   GDestroyNotify custom_slaving_cb_notify;
++
++  /* drop data if late */
++  gboolean drop_on_late;
+ };
+ 
+ /* BaseAudioSink signals and args */
+@@ -189,7 +192,6 @@ static GstCaps *gst_audio_base_sink_fixate (GstBaseSink * bsink,
+ static gboolean gst_audio_base_sink_query_pad (GstBaseSink * bsink,
+     GstQuery * query);
+ 
+-
+ /* static guint gst_audio_base_sink_signals[LAST_SIGNAL] = { 0 }; */
+ 
+ static void
+@@ -314,6 +316,7 @@ gst_audio_base_sink_init (GstAudioBaseSink * audiobasesink)
+   audiobasesink->priv->custom_slaving_callback = NULL;
+   audiobasesink->priv->custom_slaving_cb_data = NULL;
+   audiobasesink->priv->custom_slaving_cb_notify = NULL;
++  audiobasesink->priv->drop_on_late = FALSE;
+ 
+   audiobasesink->provided_clock = gst_audio_clock_new ("GstAudioSinkClock",
+       (GstAudioClockGetTimeFunc) gst_audio_base_sink_get_time, audiobasesink,
+@@ -845,6 +848,24 @@ gst_audio_base_sink_get_discont_wait (GstAudioBaseSink * sink)
+   return result;
+ }
+ 
++/**
++ * gst_audio_base_sink_set_drop_on_late:
++ * @sink: a #GstAudioBaseSink
++ *
++ * Configures whether @sink should drop late data or not.
++ */
++void
++gst_audio_base_sink_set_drop_on_late (GstAudioBaseSink * sink,
++    gboolean drop_on_late)
++{
++  g_return_if_fail (GST_IS_AUDIO_BASE_SINK (sink));
++
++  GST_OBJECT_LOCK (sink);
++  sink->priv->drop_on_late = drop_on_late;
++  GST_OBJECT_UNLOCK (sink);
++}
++
++
+ static void
+ gst_audio_base_sink_set_property (GObject * object, guint prop_id,
+     const GValue * value, GParamSpec * pspec)
+@@ -1244,8 +1265,13 @@ gst_audio_base_sink_get_offset (GstAudioBaseSink * sink)
+   /* see how far away it is from the write segment */
+   diff = writeseg - segdone;
+   if (diff < 0) {
+-    /* sample would be dropped, position to next playable position */
+-    sample = (segdone + 1) * sps;
++    if (!sink->priv->drop_on_late) {
++      /* sample would be dropped, position to next playable position */
++      sample = (segdone + 1) * sps;
++    } else {
++      GST_DEBUG_OBJECT (sink, "Dropping %" G_GUINT64_FORMAT " late samples",
++                         -(diff * sps));
++    }
+   }
+ 
+   return sample;
+@@ -1848,6 +1874,12 @@ gst_audio_base_sink_render (GstBaseSink * bsink, GstBuffer * buf)
+   if (G_UNLIKELY (!gst_audio_ring_buffer_is_acquired (ringbuf)))
+     goto wrong_state;
+ 
++  if (bclass->setup_render) {
++    if (!bclass->setup_render (sink, buf)) {
++      goto too_late;
++    }
++  }
++
+   /* Wait for upstream latency before starting the ringbuffer, we do this so
+    * that we can align the first sample of the ringbuffer to the base_time +
+    * latency. */
+@@ -2079,6 +2111,7 @@ gst_audio_base_sink_render (GstBaseSink * bsink, GstBuffer * buf)
+   if (G_UNLIKELY (render_start == 0 && render_stop == 0))
+     goto too_late;
+ 
++
+   /* and bring the time to the rate corrected offset in the buffer */
+   render_start = gst_util_uint64_scale_int (render_start, rate, GST_SECOND);
+   render_stop = gst_util_uint64_scale_int (render_stop, rate, GST_SECOND);
+diff --git a/gst-libs/gst/audio/gstaudiobasesink.h b/gst-libs/gst/audio/gstaudiobasesink.h
+index 8c709bd..863641c 100644
+--- a/gst-libs/gst/audio/gstaudiobasesink.h
++++ b/gst-libs/gst/audio/gstaudiobasesink.h
+@@ -218,6 +218,9 @@ struct _GstAudioBaseSinkClass {
+   /* subclass payloader */
+   GstBuffer*          (*payload)            (GstAudioBaseSink *sink,
+                                              GstBuffer        *buffer);
++
++  gboolean            (*setup_render)       (GstAudioBaseSink *sink,
++                                             GstBuffer        *buf);
+   /*< private >*/
+   gpointer _gst_reserved[GST_PADDING];
+ };
+@@ -258,6 +261,8 @@ gst_audio_base_sink_set_custom_slaving_callback        (GstAudioBaseSink * sink,
+ 
+ void gst_audio_base_sink_report_device_failure         (GstAudioBaseSink * sink);
+ 
++void      gst_audio_base_sink_set_drop_on_late         (GstAudioBaseSink * sink, gboolean drop_on_late);
++
+ #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GstAudioBaseSink, gst_object_unref)
+ #endif
+diff --git a/pkgconfig/Makefile.am b/pkgconfig/Makefile.am
+index 9976f95..ee42a05 100644
+--- a/pkgconfig/Makefile.am
++++ b/pkgconfig/Makefile.am
+@@ -1,6 +1,7 @@
+ ### all of the standard pc files we need to generate
+ pcverfiles =  \
+ 	gstreamer-allocators-@GST_API_VERSION@.pc \
++	gstreamer-alsaclock-@GST_API_VERSION@.pc \
+ 	gstreamer-audio-@GST_API_VERSION@.pc \
+ 	gstreamer-app-@GST_API_VERSION@.pc \
+ 	gstreamer-fft-@GST_API_VERSION@.pc \
+@@ -14,6 +15,7 @@ pcverfiles =  \
+ 	gstreamer-plugins-base-@GST_API_VERSION@.pc
+ pcverfiles_uninstalled = \
+ 	gstreamer-allocators-@GST_API_VERSION@-uninstalled.pc \
++	gstreamer-alsaclock-@GST_API_VERSION@-uninstalled.pc \
+ 	gstreamer-audio-@GST_API_VERSION@-uninstalled.pc \
+ 	gstreamer-app-@GST_API_VERSION@-uninstalled.pc \
+ 	gstreamer-fft-@GST_API_VERSION@-uninstalled.pc \
+@@ -44,6 +46,7 @@ pkgconfig_DATA = $(pcverfiles)
+ CLEANFILES = $(pcverfiles) $(pcverfiles_uninstalled)
+ pcinfiles = \
+ 		   gstreamer-allocators.pc.in gstreamer-allocators-uninstalled.pc.in \
++		   gstreamer-alsaclock.pc.in gstreamer-alsaclock-uninstalled.pc.in \
+            gstreamer-audio.pc.in gstreamer-audio-uninstalled.pc.in \
+            gstreamer-app.pc.in gstreamer-app-uninstalled.pc.in \
+            gstreamer-fft.pc.in gstreamer-fft-uninstalled.pc.in \
+diff --git a/pkgconfig/gstreamer-alsaclock-uninstalled.pc.in b/pkgconfig/gstreamer-alsaclock-uninstalled.pc.in
+new file mode 100644
+index 0000000..89e7c41
+--- /dev/null
++++ b/pkgconfig/gstreamer-alsaclock-uninstalled.pc.in
+@@ -0,0 +1,13 @@
++# the standard variables don't make sense for an uninstalled copy
++prefix=
++exec_prefix=
++libdir=
++# includedir is builddir because it is used to find gstconfig.h in places
++includedir=@abs_top_builddir@/gst-libs
++
++Name: GStreamer Alsa Clock Library, Uninstalled
++Description: Alsa Clock implementation, uninstalled
++Version: @VERSION@
++Requires: gstreamer-@GST_API_VERSION@ alsa >= 1.0.29
++Libs: @abs_top_builddir@/gst-libs/ext/alsaclock/libgstalsaclock-@GST_API_VERSION@.la
++Cflags: -I@abs_top_srcdir@/gst-libs -I@abs_top_builddir@/gst-libs
+diff --git a/pkgconfig/gstreamer-alsaclock.pc.in b/pkgconfig/gstreamer-alsaclock.pc.in
+new file mode 100644
+index 0000000..ec961dc
+--- /dev/null
++++ b/pkgconfig/gstreamer-alsaclock.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: Gstreamer Alsa Clock Library
++Description: ALSA Clock implementation
++Requires: gstreamer-@GST_API_VERSION@ alsa >= 1.0.29
++Version: @VERSION@
++Libs: -L${libdir} -lgstalsaclock-@GST_API_VERSION@
++Cflags: -I{includedir}
+diff --git a/pkgconfig/gstreamer-plugins-base-uninstalled.pc.in b/pkgconfig/gstreamer-plugins-base-uninstalled.pc.in
+index eaf378b..b89cbfa 100644
+--- a/pkgconfig/gstreamer-plugins-base-uninstalled.pc.in
++++ b/pkgconfig/gstreamer-plugins-base-uninstalled.pc.in
+@@ -10,7 +10,7 @@ Name: GStreamer Base Plugins Libraries, Uninstalled
+ Description: Streaming media framework, base plugins libraries, uninstalled
+ Version: @VERSION@
+ Requires: gstreamer-@GST_API_VERSION@
+-Libs: -L@abs_top_builddir@/gst-libs/gst/allocators/.libs -L@abs_top_builddir@/gst-libs/gst/app/.libs -L@abs_top_builddir@/gst-libs/gst/audio/.libs -L@abs_top_builddir@/gst-libs/gst/fft/.libs -L@abs_top_builddir@/gst-libs/gst/pbutils/.libs -L@abs_top_builddir@/gst-libs/gst/riff/.libs -L@abs_top_builddir@/gst-libs/gst/rtp/.libs -L@abs_top_builddir@/gst-libs/gst/rtsp/.libs -L@abs_top_builddir@/gst-libs/gst/sdp/.libs -L@abs_top_builddir@/gst-libs/gst/tag/.libs -L@abs_top_builddir@/gst-libs/gst/video/.libs
++Libs: -L@abs_top_builddir@/gst-libs/ext/alsaclock/.libs -L@abs_top_builddir@/gst-libs/gst/allocators/.libs -L@abs_top_builddir@/gst-libs/gst/app/.libs -L@abs_top_builddir@/gst-libs/gst/audio/.libs -L@abs_top_builddir@/gst-libs/gst/fft/.libs -L@abs_top_builddir@/gst-libs/gst/pbutils/.libs -L@abs_top_builddir@/gst-libs/gst/riff/.libs -L@abs_top_builddir@/gst-libs/gst/rtp/.libs -L@abs_top_builddir@/gst-libs/gst/rtsp/.libs -L@abs_top_builddir@/gst-libs/gst/sdp/.libs -L@abs_top_builddir@/gst-libs/gst/tag/.libs -L@abs_top_builddir@/gst-libs/gst/video/.libs
+ Cflags: -I@abs_top_srcdir@/gst-libs -I@abs_top_builddir@/gst-libs
+ 
+-libraries=allocators app audio fft pbutils riff rtp rtsp sdp tag video
++libraries=allocators alsaclock app audio fft pbutils riff rtp rtsp sdp tag video
+diff --git a/pkgconfig/gstreamer-plugins-base.pc.in b/pkgconfig/gstreamer-plugins-base.pc.in
+index e817746..14e6764 100644
+--- a/pkgconfig/gstreamer-plugins-base.pc.in
++++ b/pkgconfig/gstreamer-plugins-base.pc.in
+@@ -11,4 +11,4 @@ Version: @VERSION@
+ Libs: -L${libdir}
+ Cflags: -I${includedir}
+ 
+-libraries=allocators app audio fft pbutils riff rtp rtsp sdp tag video
++libraries=allocators alsaclock app audio fft pbutils riff rtp rtsp sdp tag video
+-- 
+2.6.2
+

--- a/multimedia/gst1-plugins-base/patches/005-alsasrc-add-uri-handler.patch
+++ b/multimedia/gst1-plugins-base/patches/005-alsasrc-add-uri-handler.patch
@@ -1,0 +1,132 @@
+From 0e02989cbaddf0e53694e4bce595033e01528760 Mon Sep 17 00:00:00 2001
+From: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+Date: Fri, 2 Dec 2016 15:20:22 +0530
+Subject: [PATCH] alsasrc: add uri handler
+
+Add alsasrc:// uri handler so that automatic plugging can be
+done from playbin
+
+Change-Id: I04d6037b6ccfb7f38017f93fbfd7eb7bfa6ae372
+Signed-off-by: Sagar Tikore <Sagar.Tikore@imgtec.com>
+Signed-off-by: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
+---
+ ext/alsa/gstalsasrc.c | 78 +++++++++++++++++++++++++++++++++++++++++++++++++--
+ ext/alsa/gstalsasrc.h |  2 ++
+ 2 files changed, 77 insertions(+), 3 deletions(-)
+
+diff --git a/ext/alsa/gstalsasrc.c b/ext/alsa/gstalsasrc.c
+index a359cc3..4f74a2d 100644
+--- a/ext/alsa/gstalsasrc.c
++++ b/ext/alsa/gstalsasrc.c
+@@ -66,9 +66,6 @@ enum
+   PROP_LAST
+ };
+ 
+-#define gst_alsasrc_parent_class parent_class
+-G_DEFINE_TYPE (GstAlsaSrc, gst_alsasrc, GST_TYPE_AUDIO_SRC);
+-
+ static void gst_alsasrc_finalize (GObject * object);
+ static void gst_alsasrc_set_property (GObject * object,
+     guint prop_id, const GValue * value, GParamSpec * pspec);
+@@ -88,6 +85,13 @@ static guint gst_alsasrc_read
+ static guint gst_alsasrc_delay (GstAudioSrc * asrc);
+ static void gst_alsasrc_reset (GstAudioSrc * asrc);
+ 
++static void gst_alsasrc_uri_handler_init (gpointer g_iface,
++    gpointer iface_data);
++
++#define gst_alsasrc_parent_class parent_class
++G_DEFINE_TYPE_WITH_CODE (GstAlsaSrc, gst_alsasrc, GST_TYPE_AUDIO_SRC,
++    G_IMPLEMENT_INTERFACE (GST_TYPE_URI_HANDLER, gst_alsasrc_uri_handler_init));
++
+ /* AlsaSrc signals and args */
+ enum
+ {
+@@ -1052,3 +1056,71 @@ prepare_error:
+     return;
+   }
+ }
++
++static void gst_alsasrc_set_device_from_uri (GstAlsaSrc *src)
++{
++  gchar *device_name = NULL;
++  gchar **p = g_strsplit (src->uri, "://", 2);
++
++  if (p[1] && p[1][0]) {
++    device_name = p[1];
++  }
++
++  g_object_set (G_OBJECT (src), "device", device_name, NULL);
++  g_strfreev (p);
++}
++
++/*** GSTURIHANDLER INTERFACE *************************************************/
++
++static GstURIType
++gst_alsasrc_uri_get_type (GType type)
++{
++  return GST_URI_SRC;
++}
++
++static const gchar *const *
++gst_alsasrc_uri_get_protocols (GType type)
++{
++  static const gchar *protocols[] = { "alsasrc", NULL };
++
++  return protocols;
++}
++
++static gchar *
++gst_alsasrc_uri_get_uri (GstURIHandler * handler)
++{
++  GstAlsaSrc *alsasrc = GST_ALSA_SRC (handler);
++
++  return alsasrc->uri ? g_strdup (alsasrc->uri) : NULL;
++}
++
++static gboolean
++gst_alsasrc_uri_set_uri (GstURIHandler * handler, const gchar * uri,
++    GError ** error)
++{
++  GstAlsaSrc *alsasrc = GST_ALSA_SRC (handler);
++
++  if (GST_STATE (alsasrc) == GST_STATE_PLAYING ||
++      GST_STATE (alsasrc) == GST_STATE_PAUSED) {
++    g_set_error (error, GST_URI_ERROR, GST_URI_ERROR_BAD_STATE,
++        "Setting the 'uri' while the element is running is "
++        "not supported");
++    return FALSE;
++  }
++
++  g_free (alsasrc->uri);
++  alsasrc->uri = g_strdup (uri);
++  gst_alsasrc_set_device_from_uri (alsasrc);
++  return TRUE;
++}
++
++static void
++gst_alsasrc_uri_handler_init (gpointer g_iface, gpointer iface_data)
++{
++  GstURIHandlerInterface *iface = (GstURIHandlerInterface *) g_iface;
++
++  iface->get_type = gst_alsasrc_uri_get_type;
++  iface->get_protocols = gst_alsasrc_uri_get_protocols;
++  iface->get_uri = gst_alsasrc_uri_get_uri;
++  iface->set_uri = gst_alsasrc_uri_set_uri;
++}
+diff --git a/ext/alsa/gstalsasrc.h b/ext/alsa/gstalsasrc.h
+index 57e2701..e07b897 100644
+--- a/ext/alsa/gstalsasrc.h
++++ b/ext/alsa/gstalsasrc.h
+@@ -52,6 +52,8 @@ struct _GstAlsaSrc {
+ 
+   gchar                 *device;
+ 
++  gchar                 *uri;
++
+   snd_pcm_t             *handle;
+   snd_pcm_hw_params_t   *hwparams;
+   snd_pcm_sw_params_t   *swparams;
+-- 
+2.6.2
+


### PR DESCRIPTION
Compile tested: MIPS, Creator Ci40 (https://github.com/CreatorDev/openwrt)

Description:
Alsa start-at facilitates starting a playback stream at a specified absolute time, which can be used to achieve synchronized playback.

This connects to CreatorDev/openwrt#112